### PR TITLE
Fix connection timeouts on java clients

### DIFF
--- a/bungee/src/main/java/org/geysermc/floodgate/BungeePlugin.java
+++ b/bungee/src/main/java/org/geysermc/floodgate/BungeePlugin.java
@@ -72,6 +72,7 @@ public class BungeePlugin extends Plugin implements Listener {
                             BedrockData.EXPECTED_LENGTH, result.getBedrockData().getDataLength()
                     ));
                 default: // only continue when SUCCESS
+                    event.completeIntent(this);
                     return;
             }
 


### PR DESCRIPTION
If you never complete the intention on async events, bungee waits forever, eventually killing the connection in a timeout. Since conning from java doesn't return a success in the handshake handler, the coder never reaches the other intention completion so you need one in the switch.