### PR TITLE
Add option to replace spaces in names

### DIFF
--- a/bukkit/src/main/java/org/geysermc/floodgate/PacketHandler.java
+++ b/bukkit/src/main/java/org/geysermc/floodgate/PacketHandler.java
@@ -127,7 +127,7 @@ public class PacketHandler extends SimpleChannelInboundHandler<Object> {
     }
 
     static {
-        handshakeHandler = new HandshakeHandler(plugin.getConfiguration().getPrivateKey(), false, plugin.getConfiguration().getUsernamePrefix());
+        handshakeHandler = new HandshakeHandler(plugin.getConfiguration().getPrivateKey(), false, plugin.getConfiguration().getUsernamePrefix(), plugin.getConfiguration().isReplaceSpaces());
 
         networkManagerClass = getPrefixedClass("NetworkManager");
         loginStartPacketClass = getPrefixedClass("PacketLoginInStart");

--- a/bungee/src/main/java/org/geysermc/floodgate/BungeePlugin.java
+++ b/bungee/src/main/java/org/geysermc/floodgate/BungeePlugin.java
@@ -35,7 +35,7 @@ public class BungeePlugin extends Plugin implements Listener {
             getDataFolder().mkdir();
         }
         config = FloodgateConfig.load(getLogger(), getDataFolder().toPath().resolve("config.yml"), BungeeFloodgateConfig.class);
-        handshakeHandler = new HandshakeHandler(config.getPrivateKey(), true, config.getUsernamePrefix());
+        handshakeHandler = new HandshakeHandler(config.getPrivateKey(), true, config.getUsernamePrefix(), config.isReplaceSpaces());
     }
 
     @Override

--- a/common/src/main/java/org/geysermc/floodgate/FloodgateConfig.java
+++ b/common/src/main/java/org/geysermc/floodgate/FloodgateConfig.java
@@ -27,6 +27,8 @@ public class FloodgateConfig {
     private DisconnectMessages messages;
     @JsonProperty(value = "username-prefix")
     private String usernamePrefix;
+    @JsonProperty(value = "replace-spaces")
+    private boolean replaceSpaces;
 
     @JsonProperty
     private boolean debug;

--- a/common/src/main/java/org/geysermc/floodgate/FloodgatePlayer.java
+++ b/common/src/main/java/org/geysermc/floodgate/FloodgatePlayer.java
@@ -37,10 +37,13 @@ public class FloodgatePlayer {
      */
     private UUID javaUniqueId;
 
-    FloodgatePlayer(BedrockData data, String prefix) {
+    FloodgatePlayer(BedrockData data, String prefix, boolean replaceSpaces) {
         version = data.getVersion();
         username = data.getUsername();
         javaUsername = prefix + data.getUsername().substring(0, Math.min(data.getUsername().length(), 16 - prefix.length()));
+        if (replaceSpaces) {
+            javaUsername = javaUsername.replaceAll(" ", "_");
+        }
         xuid = data.getXuid();
         deviceOS = DeviceOS.getById(data.getDeviceId());
         languageCode = data.getLanguageCode();

--- a/common/src/main/java/org/geysermc/floodgate/HandshakeHandler.java
+++ b/common/src/main/java/org/geysermc/floodgate/HandshakeHandler.java
@@ -18,11 +18,13 @@ public class HandshakeHandler {
     private PrivateKey privateKey;
     private boolean bungee;
     private String usernamePrefix;
+    private boolean replaceSpaces;
 
-    public HandshakeHandler(@NonNull PrivateKey privateKey, boolean bungee, String usernamePrefix) {
+    public HandshakeHandler(@NonNull PrivateKey privateKey, boolean bungee, String usernamePrefix, boolean replaceSpaces) {
         this.privateKey = privateKey;
         this.bungee = bungee;
         this.usernamePrefix = usernamePrefix;
+        this.replaceSpaces = replaceSpaces;
     }
 
     public HandshakeResult handle(@NonNull String handshakeData) {
@@ -42,7 +44,7 @@ public class HandshakeHandler {
                 return ResultType.INVALID_DATA_LENGTH.getCachedResult();
             }
 
-            FloodgatePlayer player = new FloodgatePlayer(bedrockData, usernamePrefix);
+            FloodgatePlayer player = new FloodgatePlayer(bedrockData, usernamePrefix, replaceSpaces);
             AbstractFloodgateAPI.players.put(player.getJavaUniqueId(), player);
             return new HandshakeResult(ResultType.SUCCESS, data, bedrockData, player);
         } catch (NoSuchPaddingException | NoSuchAlgorithmException | InvalidKeyException | IllegalBlockSizeException | BadPaddingException e) {

--- a/velocity/src/main/java/org/geysermc/floodgate/VelocityPlugin.java
+++ b/velocity/src/main/java/org/geysermc/floodgate/VelocityPlugin.java
@@ -78,7 +78,7 @@ public class VelocityPlugin {
         }
 
         config = FloodgateConfig.load(logger, dataFolder.toPath().resolve("config.yml"), VelocityFloodgateConfig.class);
-        handshakeHandler = new HandshakeHandler(config.getPrivateKey(), true, config.getUsernamePrefix());
+        handshakeHandler = new HandshakeHandler(config.getPrivateKey(), true, config.getUsernamePrefix(), config.isReplaceSpaces());
     }
 
     @Subscribe


### PR DESCRIPTION
A lot of java plugins cannot handle spaces being passed when looking for a username (commands are a huge issue with this). This pr adds an option to replace spaces in names with underscores.