### PR TITLE
Added PlaceholderAPI device support

### DIFF
--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -16,6 +16,10 @@
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
+        <repository>
+            <id>placeholderapi</id>
+            <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -35,6 +39,12 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-codec</artifactId>
             <version>4.1.43.Final</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.10.5</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/bukkit/src/main/java/org/geysermc/floodgate/BukkitPlugin.java
+++ b/bukkit/src/main/java/org/geysermc/floodgate/BukkitPlugin.java
@@ -33,6 +33,10 @@ public class BukkitPlugin extends JavaPlugin {
                 getServer().getPluginManager().disablePlugin(this);
             }
         }
+
+        if (getServer().getPluginManager().getPlugin("PlaceholderAPI") != null) {
+            new FloodgatePlaceholder(this).register();
+        }
     }
 
     @Override

--- a/bukkit/src/main/java/org/geysermc/floodgate/FloodgatePlaceholder.java
+++ b/bukkit/src/main/java/org/geysermc/floodgate/FloodgatePlaceholder.java
@@ -57,36 +57,40 @@ public class FloodgatePlaceholder extends PlaceholderExpansion {
      */
     private String getPlayerDeviceString(Player player) {
         if (FloodgateAPI.isBedrockPlayer(player.getUniqueId())) {
-            FloodgatePlayer floodgatePlayer = FloodgateAPI.getPlayer(player.getUniqueId());
-            switch (floodgatePlayer.getDeviceOS()) {
-                case ANDROID:
-                    return plugin.getConfiguration().getPlaceholders().getAndroid().replace("&", "§");
-                case IOS:
-                    return plugin.getConfiguration().getPlaceholders().getIOS().replace("&", "§");
-                case OSX:
-                    return plugin.getConfiguration().getPlaceholders().getOSX().replace("&", "§");
-                case FIREOS:
-                    return plugin.getConfiguration().getPlaceholders().getFireos().replace("&", "§");
-                case GEARVR:
-                    return plugin.getConfiguration().getPlaceholders().getGearVR().replace("&", "§");
-                case HOLOLENS:
-                    return plugin.getConfiguration().getPlaceholders().getHololens().replace("&", "§");
-                case WIN10:
-                    return plugin.getConfiguration().getPlaceholders().getWin10().replace("&", "§");
-                case WIN32:
-                    return plugin.getConfiguration().getPlaceholders().getWin32().replace("&", "§");
-                case DEDICATED:
-                    return plugin.getConfiguration().getPlaceholders().getDedicated().replace("&", "§");
-                case ORBIS:
-                    return plugin.getConfiguration().getPlaceholders().getOrbis().replace("&", "§");
-                case NX:
-                    return plugin.getConfiguration().getPlaceholders().getNX().replace("&", "§");
-                case SWITCH:
-                    return plugin.getConfiguration().getPlaceholders().getNintendoSwitch().replace("&", "§");
-                case XBOX_ONE:
-                    return plugin.getConfiguration().getPlaceholders().getXboxOne().replace("&", "§");
-                default:
-                    return plugin.getConfiguration().getPlaceholders().getUnknown().replace("&", "§");
+            if (plugin.getConfiguration().isSpecificDeviceDescriptors()) {
+                FloodgatePlayer floodgatePlayer = FloodgateAPI.getPlayer(player.getUniqueId());
+                switch (floodgatePlayer.getDeviceOS()) {
+                    case ANDROID:
+                        return plugin.getConfiguration().getPlaceholders().getAndroid().replace("&", "§");
+                    case IOS:
+                        return plugin.getConfiguration().getPlaceholders().getIOS().replace("&", "§");
+                    case OSX:
+                        return plugin.getConfiguration().getPlaceholders().getOSX().replace("&", "§");
+                    case FIREOS:
+                        return plugin.getConfiguration().getPlaceholders().getFireos().replace("&", "§");
+                    case GEARVR:
+                        return plugin.getConfiguration().getPlaceholders().getGearVR().replace("&", "§");
+                    case HOLOLENS:
+                        return plugin.getConfiguration().getPlaceholders().getHololens().replace("&", "§");
+                    case WIN10:
+                        return plugin.getConfiguration().getPlaceholders().getWin10().replace("&", "§");
+                    case WIN32:
+                        return plugin.getConfiguration().getPlaceholders().getWin32().replace("&", "§");
+                    case DEDICATED:
+                        return plugin.getConfiguration().getPlaceholders().getDedicated().replace("&", "§");
+                    case ORBIS:
+                        return plugin.getConfiguration().getPlaceholders().getOrbis().replace("&", "§");
+                    case NX:
+                        return plugin.getConfiguration().getPlaceholders().getNX().replace("&", "§");
+                    case SWITCH:
+                        return plugin.getConfiguration().getPlaceholders().getNintendoSwitch().replace("&", "§");
+                    case XBOX_ONE:
+                        return plugin.getConfiguration().getPlaceholders().getXboxOne().replace("&", "§");
+                    default:
+                        return plugin.getConfiguration().getPlaceholders().getUnknown().replace("&", "§");
+                }
+            }else{
+                return plugin.getConfiguration().getPlaceholders().getGeneric().replace("&", "§");
             }
         } else {
             return plugin.getConfiguration().getPlaceholders().getJava().replace("&", "§");

--- a/bukkit/src/main/java/org/geysermc/floodgate/FloodgatePlaceholder.java
+++ b/bukkit/src/main/java/org/geysermc/floodgate/FloodgatePlaceholder.java
@@ -42,8 +42,43 @@ public class FloodgatePlaceholder extends PlaceholderExpansion {
             return "";
         }
 
-        if(identifier.equals("device")){
-            return getPlayerDeviceString(player);
+        switch (identifier) {
+            case "device":
+                return getPlayerDeviceString(player);
+
+            case "locale":
+            case "locale_upper":
+                if (FloodgateAPI.isBedrockPlayer(player.getUniqueId())) {
+                    FloodgatePlayer floodgatePlayer = FloodgateAPI.getPlayer(player.getUniqueId());
+                    boolean upper = identifier.endsWith("_upper");
+                    return plugin.getConfiguration().getPlaceholders().getLocale().getFound().replace("%locale%", upper ? floodgatePlayer.getLanguageCode().toUpperCase() : floodgatePlayer.getLanguageCode().toLowerCase());
+                } else {
+                    return plugin.getConfiguration().getPlaceholders().getLocale().getNone();
+                }
+
+            case "version":
+                if (FloodgateAPI.isBedrockPlayer(player.getUniqueId())) {
+                    FloodgatePlayer floodgatePlayer = FloodgateAPI.getPlayer(player.getUniqueId());
+                    return plugin.getConfiguration().getPlaceholders().getVersion().getFound().replace("%version%", floodgatePlayer.getVersion());
+                } else {
+                    return plugin.getConfiguration().getPlaceholders().getVersion().getNone();
+                }
+
+            case "username":
+                if (FloodgateAPI.isBedrockPlayer(player.getUniqueId())) {
+                    FloodgatePlayer floodgatePlayer = FloodgateAPI.getPlayer(player.getUniqueId());
+                    return plugin.getConfiguration().getPlaceholders().getXboxUsername().getFound().replace("%username%", floodgatePlayer.getUsername());
+                } else {
+                    return plugin.getConfiguration().getPlaceholders().getXboxUsername().getNone();
+                }
+
+            case "xuid":
+                if (FloodgateAPI.isBedrockPlayer(player.getUniqueId())) {
+                    FloodgatePlayer floodgatePlayer = FloodgateAPI.getPlayer(player.getUniqueId());
+                    return plugin.getConfiguration().getPlaceholders().getXboxXuid().getFound().replace("%xuid%", floodgatePlayer.getXuid());
+                } else {
+                    return plugin.getConfiguration().getPlaceholders().getXboxXuid().getNone();
+                }
         }
 
         return null;
@@ -57,43 +92,43 @@ public class FloodgatePlaceholder extends PlaceholderExpansion {
      */
     private String getPlayerDeviceString(Player player) {
         if (FloodgateAPI.isBedrockPlayer(player.getUniqueId())) {
-            if (plugin.getConfiguration().isSpecificDeviceDescriptors()) {
+            if (plugin.getConfiguration().getPlaceholders().isSpecificDeviceDescriptors()) {
                 FloodgatePlayer floodgatePlayer = FloodgateAPI.getPlayer(player.getUniqueId());
                 switch (floodgatePlayer.getDeviceOS()) {
                     case ANDROID:
-                        return plugin.getConfiguration().getPlaceholders().getAndroid().replace("&", "§");
+                        return plugin.getConfiguration().getPlaceholders().getDevice().getAndroid().replace("&", "§");
                     case IOS:
-                        return plugin.getConfiguration().getPlaceholders().getIOS().replace("&", "§");
+                        return plugin.getConfiguration().getPlaceholders().getDevice().getIOS().replace("&", "§");
                     case OSX:
-                        return plugin.getConfiguration().getPlaceholders().getOSX().replace("&", "§");
+                        return plugin.getConfiguration().getPlaceholders().getDevice().getOSX().replace("&", "§");
                     case FIREOS:
-                        return plugin.getConfiguration().getPlaceholders().getFireos().replace("&", "§");
+                        return plugin.getConfiguration().getPlaceholders().getDevice().getFireos().replace("&", "§");
                     case GEARVR:
-                        return plugin.getConfiguration().getPlaceholders().getGearVR().replace("&", "§");
+                        return plugin.getConfiguration().getPlaceholders().getDevice().getGearVR().replace("&", "§");
                     case HOLOLENS:
-                        return plugin.getConfiguration().getPlaceholders().getHololens().replace("&", "§");
+                        return plugin.getConfiguration().getPlaceholders().getDevice().getHololens().replace("&", "§");
                     case WIN10:
-                        return plugin.getConfiguration().getPlaceholders().getWin10().replace("&", "§");
+                        return plugin.getConfiguration().getPlaceholders().getDevice().getWin10().replace("&", "§");
                     case WIN32:
-                        return plugin.getConfiguration().getPlaceholders().getWin32().replace("&", "§");
+                        return plugin.getConfiguration().getPlaceholders().getDevice().getWin32().replace("&", "§");
                     case DEDICATED:
-                        return plugin.getConfiguration().getPlaceholders().getDedicated().replace("&", "§");
+                        return plugin.getConfiguration().getPlaceholders().getDevice().getDedicated().replace("&", "§");
                     case ORBIS:
-                        return plugin.getConfiguration().getPlaceholders().getOrbis().replace("&", "§");
+                        return plugin.getConfiguration().getPlaceholders().getDevice().getOrbis().replace("&", "§");
                     case NX:
-                        return plugin.getConfiguration().getPlaceholders().getNX().replace("&", "§");
+                        return plugin.getConfiguration().getPlaceholders().getDevice().getNX().replace("&", "§");
                     case SWITCH:
-                        return plugin.getConfiguration().getPlaceholders().getNintendoSwitch().replace("&", "§");
+                        return plugin.getConfiguration().getPlaceholders().getDevice().getNintendoSwitch().replace("&", "§");
                     case XBOX_ONE:
-                        return plugin.getConfiguration().getPlaceholders().getXboxOne().replace("&", "§");
+                        return plugin.getConfiguration().getPlaceholders().getDevice().getXboxOne().replace("&", "§");
                     default:
-                        return plugin.getConfiguration().getPlaceholders().getUnknown().replace("&", "§");
+                        return plugin.getConfiguration().getPlaceholders().getDevice().getUnknown().replace("&", "§");
                 }
             }else{
-                return plugin.getConfiguration().getPlaceholders().getGeneric().replace("&", "§");
+                return plugin.getConfiguration().getPlaceholders().getDevice().getGeneric().replace("&", "§");
             }
         } else {
-            return plugin.getConfiguration().getPlaceholders().getJava().replace("&", "§");
+            return plugin.getConfiguration().getPlaceholders().getDevice().getJava().replace("&", "§");
         }
     }
 

--- a/bukkit/src/main/java/org/geysermc/floodgate/FloodgatePlaceholder.java
+++ b/bukkit/src/main/java/org/geysermc/floodgate/FloodgatePlaceholder.java
@@ -1,0 +1,96 @@
+package org.geysermc.floodgate;
+
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.entity.Player;
+
+public class FloodgatePlaceholder extends PlaceholderExpansion {
+
+    private BukkitPlugin plugin;
+
+    public FloodgatePlaceholder(BukkitPlugin plugin){
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean persist(){
+        return true;
+    }
+
+    @Override
+    public boolean canRegister(){
+        return true;
+    }
+
+    @Override
+    public String getAuthor(){
+        return plugin.getDescription().getAuthors().toString();
+    }
+
+    @Override
+    public String getIdentifier(){
+        return "floodgate";
+    }
+
+    @Override
+    public String getVersion(){
+        return plugin.getDescription().getVersion();
+    }
+
+    @Override
+    public String onPlaceholderRequest(Player player, String identifier){
+        if(player == null){
+            return "";
+        }
+
+        if(identifier.equals("device")){
+            return getPlayerDeviceString(player);
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the device string from config for the specified player
+     *
+     * @param player The player to get the device for
+     * @return The formatted device string from config
+     */
+    private String getPlayerDeviceString(Player player) {
+        if (FloodgateAPI.isBedrockPlayer(player.getUniqueId())) {
+            FloodgatePlayer floodgatePlayer = FloodgateAPI.getPlayer(player.getUniqueId());
+            switch (floodgatePlayer.getDeviceOS()) {
+                case ANDROID:
+                    return plugin.getConfiguration().getPlaceholders().getAndroid().replace("&", "§");
+                case IOS:
+                    return plugin.getConfiguration().getPlaceholders().getIOS().replace("&", "§");
+                case OSX:
+                    return plugin.getConfiguration().getPlaceholders().getOSX().replace("&", "§");
+                case FIREOS:
+                    return plugin.getConfiguration().getPlaceholders().getFireos().replace("&", "§");
+                case GEARVR:
+                    return plugin.getConfiguration().getPlaceholders().getGearVR().replace("&", "§");
+                case HOLOLENS:
+                    return plugin.getConfiguration().getPlaceholders().getHololens().replace("&", "§");
+                case WIN10:
+                    return plugin.getConfiguration().getPlaceholders().getWin10().replace("&", "§");
+                case WIN32:
+                    return plugin.getConfiguration().getPlaceholders().getWin32().replace("&", "§");
+                case DEDICATED:
+                    return plugin.getConfiguration().getPlaceholders().getDedicated().replace("&", "§");
+                case ORBIS:
+                    return plugin.getConfiguration().getPlaceholders().getOrbis().replace("&", "§");
+                case NX:
+                    return plugin.getConfiguration().getPlaceholders().getNX().replace("&", "§");
+                case SWITCH:
+                    return plugin.getConfiguration().getPlaceholders().getNintendoSwitch().replace("&", "§");
+                case XBOX_ONE:
+                    return plugin.getConfiguration().getPlaceholders().getXboxOne().replace("&", "§");
+                default:
+                    return plugin.getConfiguration().getPlaceholders().getUnknown().replace("&", "§");
+            }
+        } else {
+            return plugin.getConfiguration().getPlaceholders().getJava().replace("&", "§");
+        }
+    }
+
+}

--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -4,3 +4,4 @@ version: ${project.version}
 author: ${project.organization.name}
 website: ${project.url}
 main: org.geysermc.floodgate.BukkitPlugin
+softdepend: [PlaceholderAPI]

--- a/common/src/main/java/org/geysermc/floodgate/FloodgateConfig.java
+++ b/common/src/main/java/org/geysermc/floodgate/FloodgateConfig.java
@@ -33,6 +33,9 @@ public class FloodgateConfig {
     @JsonProperty(value = "disconnect")
     private DisconnectMessages messages;
 
+    @JsonProperty(value = "specific-device-descriptors")
+    private boolean specificDeviceDescriptors;
+
     @JsonProperty(value = "device-placeholder")
     private DevicePlaceholders placeholders;
 
@@ -55,6 +58,9 @@ public class FloodgateConfig {
     public static class DevicePlaceholders {
         @JsonProperty("java")
         private String java;
+
+        @JsonProperty("generic")
+        private String generic;
 
         @JsonProperty("unknown")
         private String unknown;

--- a/common/src/main/java/org/geysermc/floodgate/FloodgateConfig.java
+++ b/common/src/main/java/org/geysermc/floodgate/FloodgateConfig.java
@@ -23,12 +23,18 @@ import java.util.logging.Logger;
 public class FloodgateConfig {
     @JsonProperty(value = "key-file-name")
     private String keyFileName;
-    @JsonProperty(value = "disconnect")
-    private DisconnectMessages messages;
+
     @JsonProperty(value = "username-prefix")
     private String usernamePrefix;
+
     @JsonProperty(value = "replace-spaces")
     private boolean replaceSpaces;
+
+    @JsonProperty(value = "disconnect")
+    private DisconnectMessages messages;
+
+    @JsonProperty(value = "device-placeholder")
+    private DevicePlaceholders placeholders;
 
     @JsonProperty
     private boolean debug;
@@ -40,8 +46,57 @@ public class FloodgateConfig {
     public static class DisconnectMessages {
         @JsonProperty("invalid-key")
         private String invalidKey;
+
         @JsonProperty("invalid-arguments-length")
         private String invalidArgumentsLength;
+    }
+
+    @Getter
+    public static class DevicePlaceholders {
+        @JsonProperty("java")
+        private String java;
+
+        @JsonProperty("unknown")
+        private String unknown;
+
+        @JsonProperty("android")
+        private String android;
+
+        @JsonProperty("ios")
+        private String iOS;
+
+        @JsonProperty("osx")
+        private String OSX;
+
+        @JsonProperty("fireos")
+        private String fireos;
+
+        @JsonProperty("gearvr")
+        private String gearVR;
+
+        @JsonProperty("hololens")
+        private String hololens;
+
+        @JsonProperty("win10")
+        private String win10;
+
+        @JsonProperty("win32")
+        private String win32;
+
+        @JsonProperty("dedicated")
+        private String dedicated;
+
+        @JsonProperty("orbis")
+        private String orbis;
+
+        @JsonProperty("nx")
+        private String NX;
+
+        @JsonProperty("switch")
+        private String nintendoSwitch;
+
+        @JsonProperty("xboxOne")
+        private String xboxOne;
     }
 
     public static FloodgateConfig load(Logger logger, Path configPath) {

--- a/common/src/main/java/org/geysermc/floodgate/FloodgateConfig.java
+++ b/common/src/main/java/org/geysermc/floodgate/FloodgateConfig.java
@@ -33,11 +33,9 @@ public class FloodgateConfig {
     @JsonProperty(value = "disconnect")
     private DisconnectMessages messages;
 
-    @JsonProperty(value = "specific-device-descriptors")
-    private boolean specificDeviceDescriptors;
 
-    @JsonProperty(value = "device-placeholder")
-    private DevicePlaceholders placeholders;
+    @JsonProperty(value = "placeholders")
+    private Placeholders placeholders;
 
     @JsonProperty
     private boolean debug;
@@ -52,6 +50,27 @@ public class FloodgateConfig {
 
         @JsonProperty("invalid-arguments-length")
         private String invalidArgumentsLength;
+    }
+
+    @Getter
+    public static class Placeholders {
+        @JsonProperty(value = "specific-device-descriptors")
+        private boolean specificDeviceDescriptors;
+
+        @JsonProperty(value = "device")
+        private DevicePlaceholders device;
+
+        @JsonProperty(value = "locale")
+        private GenericPlaceholders locale;
+
+        @JsonProperty(value = "version")
+        private GenericPlaceholders version;
+
+        @JsonProperty(value = "xbox-username")
+        private GenericPlaceholders xboxUsername;
+
+        @JsonProperty(value = "xbox-xuid")
+        private GenericPlaceholders xboxXuid;
     }
 
     @Getter
@@ -103,6 +122,15 @@ public class FloodgateConfig {
 
         @JsonProperty("xboxOne")
         private String xboxOne;
+    }
+
+    @Getter
+    public static class GenericPlaceholders {
+        @JsonProperty("found")
+        private String found;
+
+        @JsonProperty("none")
+        private String none;
     }
 
     public static FloodgateConfig load(Logger logger, Path configPath) {

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -18,3 +18,21 @@ disconnect:
   # The disconnect message Geyser users should get when connecting
   # to the server with the correct key but not with the correct data format
   invalid-arguments-length: Expected {0} arguments, got {1}. Is Geyser up-to-date?
+
+# Used in PlaceholderAPI supported by the Bukkit plugin (%floodgate_device%)
+device-placeholder:
+  java: "&8[&aJava&8]"
+  unknown: "&8[&aUnknown&8]"
+  android: "&8[&aAndroid&8]"
+  ios: "&8[&bi&fOS&8]"
+  osx: "&8[&fOS&bX&8]"
+  fireos: "&8[&6F&fireOS&8]"
+  gearvr: "&8[&7Gear&fVR&8]"
+  hololens: "&8[&7Holo&fLens&8]"
+  win10: "&8[&3Win&f10&8]"
+  win32: "&8[&3Win&f32&8]"
+  dedicated: "&8[&aDED&8]"
+  orbis: "&8[&3ORBIS&8]"
+  nx: "&8[&eNX&8]"
+  switch: "&8[&4Switch&8]"
+  xboxOne: "&8[&2Xbox&fOne&8]"

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -19,9 +19,13 @@ disconnect:
   # to the server with the correct key but not with the correct data format
   invalid-arguments-length: Expected {0} arguments, got {1}. Is Geyser up-to-date?
 
+# Enables the use of specific device descriptors for PlaceholderAPI
+specific-device-descriptors: true
+
 # Used in PlaceholderAPI supported by the Bukkit plugin (%floodgate_device%)
 device-placeholder:
   java: "&8[&aJava&8]"
+  generic: "&8[&7Bedrock&8]"
   unknown: "&8[&aUnknown&8]"
   android: "&8[&aAndroid&8]"
   ios: "&8[&bi&fOS&8]"

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -19,24 +19,47 @@ disconnect:
   # to the server with the correct key but not with the correct data format
   invalid-arguments-length: Expected {0} arguments, got {1}. Is Geyser up-to-date?
 
-# Enables the use of specific device descriptors for PlaceholderAPI
-specific-device-descriptors: true
 
-# Used in PlaceholderAPI supported by the Bukkit plugin (%floodgate_device%)
-device-placeholder:
-  java: "&8[&aJava&8]"
-  generic: "&8[&7Bedrock&8]"
-  unknown: "&8[&aUnknown&8]"
-  android: "&8[&aAndroid&8]"
-  ios: "&8[&bi&fOS&8]"
-  osx: "&8[&fOS&bX&8]"
-  fireos: "&8[&6F&fireOS&8]"
-  gearvr: "&8[&7Gear&fVR&8]"
-  hololens: "&8[&7Holo&fLens&8]"
-  win10: "&8[&3Win&f10&8]"
-  win32: "&8[&3Win&f32&8]"
-  dedicated: "&8[&aDED&8]"
-  orbis: "&8[&3ORBIS&8]"
-  nx: "&8[&eNX&8]"
-  switch: "&8[&4Switch&8]"
-  xboxOne: "&8[&2Xbox&fOne&8]"
+# Used in PlaceholderAPI supported by the Bukkit plugin
+placeholders:
+  # Enables the use of specific device descriptors for PlaceholderAPI
+  specific-device-descriptors: true
+
+  # The device strings for the placeholder
+  device:
+    java: "&8[&aJava&8]"
+    generic: "&8[&7Bedrock&8]"
+    unknown: "&8[&aUnknown&8]"
+    android: "&8[&aAndroid&8]"
+    ios: "&8[&bi&fOS&8]"
+    osx: "&8[&fOS&bX&8]"
+    fireos: "&8[&6F&fireOS&8]"
+    gearvr: "&8[&7Gear&fVR&8]"
+    hololens: "&8[&7Holo&fLens&8]"
+    win10: "&8[&3Win&f10&8]"
+    win32: "&8[&3Win&f32&8]"
+    dedicated: "&8[&aDED&8]"
+    orbis: "&8[&3ORBIS&8]"
+    nx: "&8[&eNX&8]"
+    switch: "&8[&4Switch&8]"
+    xboxOne: "&8[&2Xbox&fOne&8]"
+
+  # The locale format (none for java users)
+  locale:
+    found: "&8[&6%locale%&8]"
+    none: "&8[&6N/A&8]"
+
+  # Bedrock version format (none for java users)
+  version:
+    found: "&8[&6%version%&8]"
+    none: "&8[&6N/A&8]"
+
+  # Xbox username format (none for java users)
+  xbox-username:
+    found: "&8[&6%username%&8]"
+    none: "&8[&6N/A&8]"
+
+  # Xbox xuid format (none for java users)
+  xbox-xuid:
+    found: "&8[&6%xuid%&8]"
+    none: "&8[&6N/A&8]"


### PR DESCRIPTION
Placeholders:
- [x] Device `%floodgate_device%`
- [x] Locale `%floodgate_locale%` and `%floodgate_locale_upper%`
- [x] Version `%floodgate_version%`
- [x] Xbox username `%floodgate_username%`
- [x] Xbox xuid `%floodgate_xuid%`

Using test command `/papi parse me %floodgate_device%%floodgate_locale%%floodgate_locale_upper%%floodgate_version%%floodgate_username%%floodgate_xuid%`
Bedrock:
![image](https://user-images.githubusercontent.com/5401186/80528040-3329e880-898d-11ea-95e4-5d5556343773.png)


Java:
![image](https://user-images.githubusercontent.com/5401186/80527741-c1519f00-898c-11ea-8b0a-999b455b77af.png)

