### PR TITLE
Fix CommandUtil implementation for BungeeCord

### DIFF
--- a/bungee/src/main/java/org/geysermc/floodgate/util/CommandUtil.java
+++ b/bungee/src/main/java/org/geysermc/floodgate/util/CommandUtil.java
@@ -8,12 +8,12 @@ import org.geysermc.floodgate.command.CommandMessage;
 public class CommandUtil extends AbstractCommandResponseCache<BaseComponent[]> implements ICommandUtil<ProxiedPlayer> {
     @Override
     public void sendMessage(ProxiedPlayer player, CommandMessage message, Object... args) {
-        player.sendMessage(getOrAddCachedMessage(message));
+        player.sendMessage(getOrAddCachedMessage(message, args));
     }
 
     @Override
     public void kickPlayer(ProxiedPlayer player, CommandMessage message, Object... args) {
-        player.disconnect(getOrAddCachedMessage(message));
+        player.disconnect(getOrAddCachedMessage(message, args));
     }
 
     @Override


### PR DESCRIPTION
Hello! I am using Floodgate with BungeeCord and I have noticed that message is not formatted correctly when I use /linkaccount
![imagen](https://user-images.githubusercontent.com/7508197/80932859-ec6e3100-8d86-11ea-97de-2a3b9b83365d.png)

And after some investigation I have discovered that the Bungeecord implementation of CommandUtil do not pass args parameter to getOrAddCachedMessage() method.