### PR TITLE
Add ProtocolSupport support

### DIFF
--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -16,6 +16,10 @@
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
+        <repository>
+            <id>Jitpack</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -42,6 +46,12 @@
             <artifactId>floodgate-common</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ProtocolSupport</groupId>
+            <artifactId>ProtocolSupport</artifactId>
+            <version>5f712a969a</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/bukkit/src/main/java/org/geysermc/floodgate/BukkitPlugin.java
+++ b/bukkit/src/main/java/org/geysermc/floodgate/BukkitPlugin.java
@@ -14,6 +14,7 @@ import org.geysermc.floodgate.command.LinkAccountCommand;
 import org.geysermc.floodgate.command.UnlinkAccountCommand;
 import org.geysermc.floodgate.injector.BukkitInjector;
 import org.geysermc.floodgate.util.CommandUtil;
+import org.geysermc.floodgate.util.ProtocolSupportUtil;
 import org.geysermc.floodgate.util.ReflectionUtil;
 
 import java.util.logging.Level;
@@ -52,6 +53,9 @@ public class BukkitPlugin extends JavaPlugin implements Listener {
 
         // Register the plugin as an event listener to we get join and leave events
         Bukkit.getServer().getPluginManager().registerEvents(this, this);
+
+        // Check for ProtocolSupport
+        ProtocolSupportUtil.checkForProtocolSupport(this);
     }
 
     @Override

--- a/bukkit/src/main/java/org/geysermc/floodgate/util/ProtocolSupportUtil.java
+++ b/bukkit/src/main/java/org/geysermc/floodgate/util/ProtocolSupportUtil.java
@@ -1,0 +1,34 @@
+package org.geysermc.floodgate.util;
+
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.Plugin;
+import org.geysermc.floodgate.FloodgateAPI;
+import protocolsupport.api.events.PlayerLoginStartEvent;
+
+public class ProtocolSupportUtil implements Listener {
+
+    public static boolean isProtocolSupport = false;
+
+    public static void checkForProtocolSupport(Plugin floodgate) {
+        if (Bukkit.getServer().getPluginManager().getPlugin("ProtocolSupport") != null) {
+            isProtocolSupport = true;
+            Bukkit.getServer().getPluginManager().registerEvents(new ProtocolSupportUtil(), floodgate);
+        }
+    }
+
+    /**
+     * Force ProtocolSupport to handle Bedrock users in offline mode, otherwise they kick us
+     * @param event ProtocolSupport's player login start event
+     */
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onLoginStart(final PlayerLoginStartEvent event) {
+        if (event.getConnection().getProfile().getUUID() == null) return; // A normal player that doesn't have a UUID set
+        if (FloodgateAPI.isBedrockPlayer(event.getConnection().getProfile().getUUID())) {
+            event.setOnlineMode(false); // Otherwise ProtocolSupport attempts to connect with online mode
+        }
+    }
+
+}

--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -5,6 +5,7 @@ author: ${project.organization.name}
 website: ${project.url}
 main: org.geysermc.floodgate.BukkitPlugin
 api-version: 1.13
+softdepend: ["Geyser-Bukkit", "ProtocolSupport"]
 commands:
   linkaccount:
     description: Link your Java and Bedrock accounts

--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -5,7 +5,7 @@ author: ${project.organization.name}
 website: ${project.url}
 main: org.geysermc.floodgate.BukkitPlugin
 api-version: 1.13
-softdepend: ["Geyser-Bukkit", "ProtocolSupport"]
+softdepend: ["ProtocolSupport"]
 commands:
   linkaccount:
     description: Link your Java and Bedrock accounts


### PR DESCRIPTION
This commit hooks into ProtocolSupport to prevent it from attempting an online connection with the Floodgate player. This has been tested with linked accounts and BungeeCord.