### PR TITLE
Add methods: getPlayerCount(), getPlayers()

### DIFF
--- a/common/src/main/java/org/geysermc/floodgate/AbstractFloodgateAPI.java
+++ b/common/src/main/java/org/geysermc/floodgate/AbstractFloodgateAPI.java
@@ -23,7 +23,6 @@ abstract class AbstractFloodgateAPI {
         }
         return null;
     }
-
     
     /**
      * Gets the Bedrock player count
@@ -32,7 +31,15 @@ abstract class AbstractFloodgateAPI {
     public int getPlayerCount() {
         return players.size();
     }
-
+    
+    /**
+     * Gets all bedrock players.
+     * @return Map<UUID, FloodgatePlayer> as all Bedrock players.
+     */
+    public Map<UUID, FloodgatePlayer> getPlayers() {
+        return players;
+    }
+    
     /**
      * Removes a player (should only be used internally)
      * @param onlineId The UUID of the online player

--- a/common/src/main/java/org/geysermc/floodgate/AbstractFloodgateAPI.java
+++ b/common/src/main/java/org/geysermc/floodgate/AbstractFloodgateAPI.java
@@ -24,6 +24,15 @@ abstract class AbstractFloodgateAPI {
         return null;
     }
 
+    
+    /**
+     * Gets the Bedrock player count
+     * @return int as amount of Bedrock players.
+     */
+    public int getPlayerCount() {
+        return players.size();
+    }
+
     /**
      * Removes a player (should only be used internally)
      * @param onlineId The UUID of the online player


### PR DESCRIPTION
The new method adds a `getPlayerCount()` function that returns an int as the amount of bedrock players online.