### PR TITLE
Switch back to UUID as XUID

### DIFF
--- a/common/src/main/java/org/geysermc/floodgate/AbstractFloodgateAPI.java
+++ b/common/src/main/java/org/geysermc/floodgate/AbstractFloodgateAPI.java
@@ -54,7 +54,7 @@ abstract class AbstractFloodgateAPI {
         for (FloodgatePlayer player1 : players.values()) {
             if (player1.isLogin() && !removeLogin || !player1.isLogin() && removeLogin) continue;
             if (!player1.getCorrectUniqueId().equals(onlineId)) continue;
-            players.remove(createJavaPlayerId(Long.parseLong(player1.getXuid())));
+            players.remove(player1.getXuid());
             return true;
         }
         return false;
@@ -68,7 +68,7 @@ abstract class AbstractFloodgateAPI {
     }
 
     static boolean removePlayer(FloodgatePlayer player) {
-        boolean removed = players.remove(createJavaPlayerId(Long.parseLong(player.getXuid())), player);
+        boolean removed = players.remove(player.getXuid(), player);
         return removed && player.getLinkedPlayer() != null;
     }
 
@@ -81,14 +81,9 @@ abstract class AbstractFloodgateAPI {
         return getPlayer(uuid) != null;
     }
 
-    /**
-     * Create a valid Java player uuid of a xuid
-     */
-    public static UUID createJavaPlayerId(long xuid) {
-        return new UUID(0, xuid);
-    }
-
     public static boolean isFloodgateId(UUID uuid) {
-        return uuid.getMostSignificantBits() == 0;
+        // Bedrock UUIDs, used by Geyser as XUID are version 3
+        // Java UUIDs are version 4
+        return uuid.version() == 3;
     }
 }

--- a/common/src/main/java/org/geysermc/floodgate/FloodgatePlayer.java
+++ b/common/src/main/java/org/geysermc/floodgate/FloodgatePlayer.java
@@ -68,7 +68,7 @@ public class FloodgatePlayer {
         deviceOS = DeviceOS.getById(data.getDeviceId());
         languageCode = data.getLanguageCode();
         inputMode = data.getInputMode();
-        javaUniqueId = AbstractFloodgateAPI.createJavaPlayerId(Long.parseLong(data.getXuid()));
+        javaUniqueId = UUID.fromString(data.getXuid());
         // every implementation (Bukkit, Bungee and Velocity) all run this async,
         // so we can block this thread
         if (PlayerLink.isEnabledAndAllowed()) {


### PR DESCRIPTION
Required for SubClient (splitscreen) support, as SubClients currently (possibly due to a bug) don't have an XUID. The oldest I found so far was https://bugs.mojang.com/browse/MCPE-71033 which is from 1.14.60.