### PR TITLE
change username-prefix from a non-win allowed character file name to …

### DIFF
--- a/bungee/src/main/resources/config.yml
+++ b/bungee/src/main/resources/config.yml
@@ -6,7 +6,7 @@ key-file-name: key.pem
 # Floodgate prepends a prefix to bedrock usernames to avoid conflicts
 # However, certain conflicts can cause issues with some plugins so this prefix is configurable using the property below
 # It is recommended to use a prefix that does not contain alphanumerical to avoid the possibility of duplicate usernames.
-username-prefix: "*"
+username-prefix: "°"
 
 # Should spaces be replaced with '_' in bedrock usernames?
 replace-spaces: true


### PR DESCRIPTION
…allowed

Change the "*" (which is not allowed by default on any windows File System) to "°"a win1252 allowed character that looks similar (not star bit circle).
Why? because we from https://github.com/SkinsRestorer/SkinsRestorerX and many other plugins use flatfiles that do not co-operate to well with this.
If there are any questions please let us know.