### PR TITLE
Properly stop the news checker

### DIFF
--- a/common/src/main/java/org/geysermc/floodgate/FloodgatePlatform.java
+++ b/common/src/main/java/org/geysermc/floodgate/FloodgatePlatform.java
@@ -145,6 +145,7 @@ public class FloodgatePlatform {
             }
         }
 
+        guice.getInstance(NewsChecker.class).shutdown();
         api.getPlayerLink().stop();
         return true;
     }


### PR DESCRIPTION
Floodgate's news checking threads should be closed when the `FloodgatePlatform` is being disabled in order to properly shut down the server. Together with GeyserMC/Floodgate-Fabric#40, this should fix GeyserMC/Floodgate-Fabric#25.