### PR TITLE
Stop using regex to replace username

### DIFF
--- a/core/src/main/java/org/geysermc/floodgate/addon/data/HandshakeDataImpl.java
+++ b/core/src/main/java/org/geysermc/floodgate/addon/data/HandshakeDataImpl.java
@@ -70,7 +70,7 @@ public class HandshakeDataImpl implements HandshakeData {
             int usernameLength = Math.min(bedrockData.getUsername().length(), 16 - prefix.length());
             javaUsername = prefix + bedrockData.getUsername().substring(0, usernameLength);
             if (config.isReplaceSpaces()) {
-                javaUsername = javaUsername.replaceAll(" ", "_");
+                javaUsername = javaUsername.replace(" ", "_");
             }
 
             javaUniqueId = Utils.getJavaUuid(bedrockData.getXuid());


### PR DESCRIPTION
The replaceAll function use regex to replace text, it calls Pattern.compile() each time the function is called, and since here the character is a blank char, it's useless to use regex. The replace function does the same behavior but without the performance drawback of the regex used.

