### PR TITLE
Switch from maven to gradle in workflow

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -1,6 +1,6 @@
 name: Build Pull Request
 
-on: [pull_request]
+on: [ pull_request ]
 
 jobs:
   build:
@@ -8,34 +8,35 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+      - uses: actions/checkout@v2
+
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
+          cache: 'gradle'
+
       - name: Build with Maven
-        run: mvn -B package
+        run: ./gradlew build
+
       - name: Archive artifacts (Floodgate Bungee)
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         if: success()
         with:
           name: Floodgate Bungee
-          path: bungee/target/floodgate-bungee.jar
+          path: bungee/build/libs/floodgate-bungee.jar
+
       - name: Archive artifacts (Floodgate Spigot)
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         if: success()
         with:
           name: Floodgate Spigot
-          path: spigot/target/floodgate-spigot.jar
+          path: spigot/build/libs/floodgate-spigot.jar
+
       - name: Archive artifacts (Floodgate Velocity)
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         if: success()
         with:
           name: Floodgate Velocity
-          path: velocity/target/floodgate-velocity.jar
+          path: velocity/build/libs/floodgate-velocity.jar


### PR DESCRIPTION
This PR update the pull request workflow since the 2.1.1 branch switched to Gradle.

I updated to actions/checkout@v2 since it's more powerful now according to their GitHub.
Also, I switched to actions/setup-java@v2 because they now have the cached directly in the plugin for maven or Gradle, so less work and finally modifier the directory of upload files.