### PR TITLE
Use constants in common for plugin message channels identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 [![Discord](https://img.shields.io/discord/613163671870242838.svg?color=%237289da&label=discord)](http://discord.geysermc.org/)
 [![HitCount](https://hits.dwyl.com/GeyserMC/Floodgate.svg)](http://hits.dwyl.com/GeyserMC/Floodgate)
 
+[Download](https://ci.opencollab.dev/job/GeyserMC/job/Floodgate/job/master/)
+
 Hybrid mode plugin to allow for connections from [Geyser](https://github.com/GeyserMC/Geyser) to join online mode servers.
 
 Geyser is an open collaboration project by [CubeCraft Games](https://cubecraft.net).
 
-See the [Floodgate](https://github.com/GeyserMC/Geyser/wiki/Floodgate) page in the Geyser Wiki for more info about the what Floodgate is, how you setup Floodgate and known issues/caveats.
-
-See the [Floodgate wiki](https://github.com/GeyserMC/Floodgate/wiki) (currently work in progress) for a more in-depth look into Floodgate, how it works and the Floodgate API.
+See the [Floodgate](https://wiki.geysermc.org/floodgate/) section in the GeyserMC Wiki for more info about what Floodgate is, how you setup Floodgate and known issues/caveats. Additionally, it includes a more in-depth look into how Floodgate works and the Floodgate API.

--- a/build-logic/src/main/kotlin/Versions.kt
+++ b/build-logic/src/main/kotlin/Versions.kt
@@ -24,7 +24,7 @@
  */
 
 object Versions {
-    const val geyserVersion = "2.0.0-SNAPSHOT"
+    const val geyserVersion = "2.0.2-SNAPSHOT"
     const val cumulusVersion = "1.0-SNAPSHOT"
     const val configUtilsVersion = "1.0-SNAPSHOT"
     const val spigotVersion = "1.13-R0.1-SNAPSHOT"

--- a/core/src/main/java/org/geysermc/floodgate/pluginmessage/channel/FormChannel.java
+++ b/core/src/main/java/org/geysermc/floodgate/pluginmessage/channel/FormChannel.java
@@ -36,6 +36,7 @@ import org.geysermc.floodgate.api.logger.FloodgateLogger;
 import org.geysermc.floodgate.config.FloodgateConfig;
 import org.geysermc.floodgate.platform.pluginmessage.PluginMessageUtils;
 import org.geysermc.floodgate.pluginmessage.PluginMessageChannel;
+import org.geysermc.floodgate.pluginmessage.PluginMessageChannels;
 
 public class FormChannel implements PluginMessageChannel {
     private final Short2ObjectMap<Form> storedForms = new Short2ObjectOpenHashMap<>();
@@ -47,7 +48,7 @@ public class FormChannel implements PluginMessageChannel {
 
     @Override
     public String getIdentifier() {
-        return "floodgate:form";
+        return PluginMessageChannels.FORM;
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/floodgate/pluginmessage/channel/SkinChannel.java
+++ b/core/src/main/java/org/geysermc/floodgate/pluginmessage/channel/SkinChannel.java
@@ -35,6 +35,7 @@ import org.geysermc.floodgate.api.player.PropertyKey;
 import org.geysermc.floodgate.config.FloodgateConfig;
 import org.geysermc.floodgate.config.ProxyFloodgateConfig;
 import org.geysermc.floodgate.pluginmessage.PluginMessageChannel;
+import org.geysermc.floodgate.pluginmessage.PluginMessageChannels;
 import org.geysermc.floodgate.skin.SkinApplier;
 import org.geysermc.floodgate.skin.SkinData;
 
@@ -45,7 +46,7 @@ public class SkinChannel implements PluginMessageChannel {
 
     @Override
     public String getIdentifier() {
-        return "floodgate:skin";
+        return PluginMessageChannels.SKIN;
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/floodgate/pluginmessage/channel/TransferChannel.java
+++ b/core/src/main/java/org/geysermc/floodgate/pluginmessage/channel/TransferChannel.java
@@ -30,13 +30,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import org.geysermc.floodgate.platform.pluginmessage.PluginMessageUtils;
 import org.geysermc.floodgate.pluginmessage.PluginMessageChannel;
+import org.geysermc.floodgate.pluginmessage.PluginMessageChannels;
 
 public class TransferChannel implements PluginMessageChannel {
     @Inject private PluginMessageUtils pluginMessageUtils;
 
     @Override
     public String getIdentifier() {
-        return "floodgate:transfer";
+        return PluginMessageChannels.TRANSFER;
     }
 
     @Override

--- a/spigot/src/main/java/org/geysermc/floodgate/pluginmessage/SpigotPluginMessageRegistration.java
+++ b/spigot/src/main/java/org/geysermc/floodgate/pluginmessage/SpigotPluginMessageRegistration.java
@@ -28,6 +28,7 @@ package org.geysermc.floodgate.pluginmessage;
 import lombok.RequiredArgsConstructor;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.messaging.Messenger;
+import org.bukkit.plugin.messaging.PluginMessageListenerRegistration;
 
 @RequiredArgsConstructor
 public class SpigotPluginMessageRegistration implements PluginMessageRegistration {
@@ -37,11 +38,15 @@ public class SpigotPluginMessageRegistration implements PluginMessageRegistratio
     public void register(PluginMessageChannel channel) {
         Messenger messenger = plugin.getServer().getMessenger();
 
-        messenger.registerIncomingPluginChannel(
+        PluginMessageListenerRegistration registration = messenger.registerIncomingPluginChannel(
                 plugin,
                 channel.getIdentifier(),
                 (channel1, player, message) ->
                         channel.handleServerCall(message, player.getUniqueId(), player.getName()));
+
+        if (!registration.isValid()) {
+            throw new IllegalStateException("Failed to register incoming plugin channel: " + channel.getIdentifier());
+        }
 
         messenger.registerOutgoingPluginChannel(plugin, channel.getIdentifier());
     }


### PR DESCRIPTION
See https://github.com/GeyserMC/Geyser/commit/87d70be10d97e3f6e119e11217ad0157ed66faf6

Successful form and transfer channels: https://mclo.gs/HIS1sb7

This was tested on master then I moved it to dev/2.1.1