### PR TITLE
hotfix(database/mongo): fix floodgate not loading with mongo when collection already exists

### DIFF
--- a/database/mongo/src/main/java/org/geysermc/floodgate/database/MongoDbDatabase.java
+++ b/database/mongo/src/main/java/org/geysermc/floodgate/database/MongoDbDatabase.java
@@ -40,6 +40,7 @@ import com.mongodb.client.model.UpdateOptions;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -336,12 +337,7 @@ public class MongoDbDatabase extends CommonPlayerLink {
     }
 
     public boolean collectionNotExists(final String collectionName) {
-        try (MongoCursor<String> collectionNames = database.listCollectionNames().cursor()) {
-            if (collectionNames.hasNext() && collectionNames.next().equals(collectionName)) {
-                return false;
-            }
-        }
-        return true;
+        return !database.listCollectionNames().into(new ArrayList<>()).contains(collectionName);
     }
 
 }


### PR DESCRIPTION
Hello, I just tested today's code for personal use and just discovered I introduce a big bug when I make the MongoDB addons.
Actually, the function collectionNotExists wasn't working, and it was causing the plugin not to load when the collections already exist. This fix just adds an empty try-catch, catching the MongoCommandException thrown by Mongo. 

Tested the fix, and it's working.