### PR TITLE
hotfix(velocity): return the value of optional and not the optional itself

### DIFF
--- a/velocity/src/main/java/org/geysermc/floodgate/util/VelocityCommandUtil.java
+++ b/velocity/src/main/java/org/geysermc/floodgate/util/VelocityCommandUtil.java
@@ -90,13 +90,13 @@ public final class VelocityCommandUtil extends CommandUtil {
     @Override
     public Object getPlayerByUuid(@NonNull UUID uuid) {
         Optional<Player> player = server.getPlayer(uuid);
-        return player.isPresent() ? player : uuid;
+        return player.isPresent() ? player.get() : uuid;
     }
 
     @Override
     public Object getPlayerByUsername(@NonNull String username) {
         Optional<Player> player = server.getPlayer(username);
-        return player.isPresent() ? player : username;
+        return player.isPresent() ? player.get() : username;
     }
 
     @Override


### PR DESCRIPTION
Actually this function return the optional and then is cast as Player in getUserAudience().
We should return the value of the optional here instead

The error: https://rentry.co/tprhp