### PR TITLE
fix(core): Switch to ProfileAudience since we require a Profile Audience as player argument

### DIFF
--- a/core/src/main/java/org/geysermc/floodgate/command/LinkAccountCommand.java
+++ b/core/src/main/java/org/geysermc/floodgate/command/LinkAccountCommand.java
@@ -46,6 +46,7 @@ import org.geysermc.floodgate.platform.command.FloodgateCommand;
 import org.geysermc.floodgate.platform.command.TranslatableMessage;
 import org.geysermc.floodgate.player.UserAudience;
 import org.geysermc.floodgate.player.UserAudience.PlayerAudience;
+import org.geysermc.floodgate.player.audience.ProfileAudience;
 import org.geysermc.floodgate.player.audience.ProfileAudienceArgument;
 import org.geysermc.floodgate.util.Constants;
 
@@ -136,7 +137,7 @@ public final class LinkAccountCommand implements FloodgateCommand {
             return;
         }
 
-        UserAudience targetUser = context.get("player");
+        ProfileAudience targetUser = context.get("player");
         String targetName = targetUser.username();
 
         link.createLinkRequest(sender.uuid(), sender.username(), targetName)


### PR DESCRIPTION
We actually cast the player context as UserAudience, but we now provide a ProfileAudience for the argument.
This was causing a CCE.

Error log: https://rentry.co/eaa46