### PR TITLE
SkinApplier now only applies a skin if a player doesn't already have one

### DIFF
--- a/bungee/src/main/java/org/geysermc/floodgate/listener/BungeeListener.java
+++ b/bungee/src/main/java/org/geysermc/floodgate/listener/BungeeListener.java
@@ -130,7 +130,7 @@ public final class BungeeListener implements Listener {
         // To fix the February 2 2022 Mojang authentication changes
         if (!config.isSendFloodgateData()) {
             FloodgatePlayer player = api.getPlayer(event.getPlayer().getUniqueId());
-            if (player != null && !player.isLinked()) {
+            if (player != null && !player.isLinked() && !skinApplier.hasSkin(player)) {
                 skinApplier.applySkin(player, new SkinData("", ""));
             }
         }

--- a/bungee/src/main/java/org/geysermc/floodgate/pluginmessage/BungeeSkinApplier.java
+++ b/bungee/src/main/java/org/geysermc/floodgate/pluginmessage/BungeeSkinApplier.java
@@ -34,8 +34,6 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
@@ -132,22 +130,14 @@ public final class BungeeSkinApplier implements SkinApplier {
             return false;
         }
 
-        List<Property> textures = new ArrayList<>();
         for (Property property : loginResult.getProperties()) {
             if (property.getName().equals("textures")) {
-                textures.add(property);
+                if (!property.getValue().isEmpty()) {
+                    return true;
+                }
             }
         }
-
-        if (textures.isEmpty()) {
-            return false;
-        }
-        for (Property p : textures) {
-            if (p.getValue().isEmpty()) {
-                return false;
-            }
-        }
-        return true;
+        return false;
     }
 
     private InitialHandler getHandler(ProxiedPlayer player) {

--- a/bungee/src/main/java/org/geysermc/floodgate/pluginmessage/BungeeSkinApplier.java
+++ b/bungee/src/main/java/org/geysermc/floodgate/pluginmessage/BungeeSkinApplier.java
@@ -34,11 +34,15 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.connection.InitialHandler;
 import net.md_5.bungee.connection.LoginResult;
+import net.md_5.bungee.protocol.Property;
 import org.geysermc.floodgate.api.logger.FloodgateLogger;
 import org.geysermc.floodgate.api.player.FloodgatePlayer;
 import org.geysermc.floodgate.skin.SkinApplier;
@@ -102,6 +106,14 @@ public final class BungeeSkinApplier implements SkinApplier {
                     LOGIN_RESULT_CONSTRUCTOR, null, null, null
             );
             ReflectionUtils.setValue(handler, LOGIN_RESULT_FIELD, loginResult);
+        }
+
+        List<Property> textures = Arrays.stream(loginResult.getProperties())
+                .filter(p -> p.getName().equals("textures"))
+                .collect(Collectors.toList());
+
+        if (!textures.isEmpty() && textures.stream().noneMatch(p -> p.getValue().isEmpty())) {
+            return;
         }
 
         Object property = ReflectionUtils.newInstance(

--- a/core/src/main/java/org/geysermc/floodgate/pluginmessage/channel/SkinChannel.java
+++ b/core/src/main/java/org/geysermc/floodgate/pluginmessage/channel/SkinChannel.java
@@ -92,7 +92,7 @@ public class SkinChannel implements PluginMessageChannel {
             return Result.kick("Got invalid skin data");
         }
 
-        if (floodgatePlayer.isLinked()) {
+        if (floodgatePlayer.isLinked() || skinApplier.hasSkin(floodgatePlayer)) {
             return Result.handled();
         }
 

--- a/core/src/main/java/org/geysermc/floodgate/skin/SkinApplier.java
+++ b/core/src/main/java/org/geysermc/floodgate/skin/SkinApplier.java
@@ -28,5 +28,14 @@ package org.geysermc.floodgate.skin;
 import org.geysermc.floodgate.api.player.FloodgatePlayer;
 
 public interface SkinApplier {
+    /**
+     * Apply a skin to a {@link FloodgatePlayer player}
+     * <p>
+     * Only applies skin to player that has a default skin
+     * </p>
+     *
+     * @param floodgatePlayer player to apply skin to
+     * @param skinData data for skin to apply to player
+     */
     void applySkin(FloodgatePlayer floodgatePlayer, SkinData skinData);
 }

--- a/core/src/main/java/org/geysermc/floodgate/skin/SkinApplier.java
+++ b/core/src/main/java/org/geysermc/floodgate/skin/SkinApplier.java
@@ -30,12 +30,18 @@ import org.geysermc.floodgate.api.player.FloodgatePlayer;
 public interface SkinApplier {
     /**
      * Apply a skin to a {@link FloodgatePlayer player}
-     * <p>
-     * Only applies skin to player that has a default skin
-     * </p>
      *
      * @param floodgatePlayer player to apply skin to
      * @param skinData data for skin to apply to player
      */
     void applySkin(FloodgatePlayer floodgatePlayer, SkinData skinData);
+
+    /**
+     * Check if a {@link FloodgatePlayer player} currently
+     * has a skin applied.
+     *
+     * @param floodgatePlayer player to check skin of
+     * @return if player has a skin
+     */
+    boolean hasSkin(FloodgatePlayer floodgatePlayer);
 }

--- a/core/src/main/java/org/geysermc/floodgate/skin/SkinUploadSocket.java
+++ b/core/src/main/java/org/geysermc/floodgate/skin/SkinUploadSocket.java
@@ -114,7 +114,7 @@ final class SkinUploadSocket extends WebSocketClient {
                                 player.getCorrectUsername());
                         return;
                     }
-                    if (!player.isLinked()) {
+                    if (!player.isLinked() && !applier.hasSkin(player)) {
                         SkinData skinData = SkinData.from(message.getAsJsonObject("data"));
                         player.addProperty(PropertyKey.SKIN_UPLOADED, skinData);
                         applier.applySkin(player, skinData);

--- a/spigot/src/main/java/org/geysermc/floodgate/pluginmessage/SpigotSkinApplier.java
+++ b/spigot/src/main/java/org/geysermc/floodgate/pluginmessage/SpigotSkinApplier.java
@@ -28,6 +28,7 @@ package org.geysermc.floodgate.pluginmessage;
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import com.mojang.authlib.properties.PropertyMap;
+import java.util.Collection;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.geysermc.floodgate.SpigotPlugin;
@@ -74,6 +75,12 @@ public final class SpigotSkinApplier implements SkinApplier {
         }
 
         PropertyMap properties = profile.getProperties();
+
+        Collection<Property> textures = properties.get("textures");
+
+        if (!textures.isEmpty() && textures.stream().noneMatch(p -> p.getValue().isEmpty())) {
+            return;
+        }
 
         properties.removeAll("textures");
         Property property = new Property("textures", skinData.getValue(), skinData.getSignature());

--- a/spigot/src/main/java/org/geysermc/floodgate/pluginmessage/SpigotSkinApplier.java
+++ b/spigot/src/main/java/org/geysermc/floodgate/pluginmessage/SpigotSkinApplier.java
@@ -29,9 +29,8 @@ import com.destroystokyo.paper.profile.ProfileProperty;
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import com.mojang.authlib.properties.PropertyMap;
-import java.util.Collection;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.geysermc.floodgate.SpigotPlugin;
@@ -66,12 +65,22 @@ public final class SpigotSkinApplier implements SkinApplier {
             return false;
         }
 
-        List<ProfileProperty> textures = player.getPlayerProfile().getProperties()
-                .stream()
-                .filter(p -> p.getName().equals("textures"))
-                .collect(Collectors.toList());
+        List<ProfileProperty> textures = new ArrayList<>();
+        for (ProfileProperty profileProperty : player.getPlayerProfile().getProperties()) {
+            if (profileProperty.getName().equals("textures")) {
+                textures.add(profileProperty);
+            }
+        }
 
-        return !textures.isEmpty() && textures.stream().noneMatch(p -> p.getValue().isEmpty());
+        if (textures.isEmpty()) {
+            return false;
+        }
+        for (ProfileProperty p : textures) {
+            if (p.getValue().isEmpty()) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private void applySkin0(FloodgatePlayer floodgatePlayer, SkinData skinData, boolean firstTry) {

--- a/spigot/src/main/java/org/geysermc/floodgate/pluginmessage/SpigotSkinApplier.java
+++ b/spigot/src/main/java/org/geysermc/floodgate/pluginmessage/SpigotSkinApplier.java
@@ -29,8 +29,6 @@ import com.destroystokyo.paper.profile.ProfileProperty;
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import com.mojang.authlib.properties.PropertyMap;
-import java.util.ArrayList;
-import java.util.List;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.geysermc.floodgate.SpigotPlugin;
@@ -65,22 +63,14 @@ public final class SpigotSkinApplier implements SkinApplier {
             return false;
         }
 
-        List<ProfileProperty> textures = new ArrayList<>();
-        for (ProfileProperty profileProperty : player.getPlayerProfile().getProperties()) {
-            if (profileProperty.getName().equals("textures")) {
-                textures.add(profileProperty);
+        for (ProfileProperty property : player.getPlayerProfile().getProperties()) {
+            if (property.getName().equals("textures")) {
+                if (!property.getValue().isEmpty()) {
+                    return true;
+                }
             }
         }
-
-        if (textures.isEmpty()) {
-            return false;
-        }
-        for (ProfileProperty p : textures) {
-            if (p.getValue().isEmpty()) {
-                return false;
-            }
-        }
-        return true;
+        return false;
     }
 
     private void applySkin0(FloodgatePlayer floodgatePlayer, SkinData skinData, boolean firstTry) {

--- a/spigot/src/main/java/org/geysermc/floodgate/pluginmessage/SpigotSkinApplier.java
+++ b/spigot/src/main/java/org/geysermc/floodgate/pluginmessage/SpigotSkinApplier.java
@@ -95,7 +95,7 @@ public final class SpigotSkinApplier implements SkinApplier {
                                 applySkin0(floodgatePlayer, skinData, false);
                             }
                         },
-                        10 * 1000);
+                        10 * 20);
             }
             return;
         }

--- a/velocity/src/main/java/org/geysermc/floodgate/util/VelocitySkinApplier.java
+++ b/velocity/src/main/java/org/geysermc/floodgate/util/VelocitySkinApplier.java
@@ -28,7 +28,9 @@ package org.geysermc.floodgate.util;
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.util.GameProfile.Property;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.geysermc.floodgate.api.player.FloodgatePlayer;
 import org.geysermc.floodgate.skin.SkinApplier;
@@ -42,6 +44,15 @@ public class VelocitySkinApplier implements SkinApplier {
     public void applySkin(FloodgatePlayer floodgatePlayer, SkinData skinData) {
         server.getPlayer(floodgatePlayer.getCorrectUniqueId()).ifPresent(player -> {
             List<Property> properties = new ArrayList<>(player.getGameProfileProperties());
+
+            List<Property> textures = properties.stream()
+                    .filter(p -> p.getName().equals("textures"))
+                    .collect(Collectors.toList());
+
+            if (!textures.isEmpty() && textures.stream().noneMatch(p -> p.getValue().isEmpty())) {
+                return;
+            }
+
             properties.add(new Property("textures", skinData.getValue(), skinData.getSignature()));
             player.setGameProfileProperties(properties);
         });

--- a/velocity/src/main/java/org/geysermc/floodgate/util/VelocitySkinApplier.java
+++ b/velocity/src/main/java/org/geysermc/floodgate/util/VelocitySkinApplier.java
@@ -51,27 +51,17 @@ public class VelocitySkinApplier implements SkinApplier {
 
     @Override
     public boolean hasSkin(FloodgatePlayer floodgatePlayer) {
-        Player player = server.getPlayer(floodgatePlayer.getCorrectUniqueId()).orElse(null);
+        Optional<Player> player = server.getPlayer(floodgatePlayer.getCorrectUniqueId());
 
-        if (player == null) {
-            return false;
-        }
-
-        List<Property> textures = new ArrayList<>();
-        for (Property property : player.getGameProfileProperties()) {
-            if (property.getName().equals("textures")) {
-                textures.add(property);
+        if (player.isPresent()) {
+            for (Property property : player.get().getGameProfileProperties()) {
+                if (property.getName().equals("textures")) {
+                    if (!property.getValue().isEmpty()) {
+                        return true;
+                    }
+                }
             }
         }
-
-        if (textures.isEmpty()) {
-            return false;
-        }
-        for (Property p : textures) {
-            if (p.getValue().isEmpty()) {
-                return false;
-            }
-        }
-        return true;
+        return false;
     }
 }

--- a/velocity/src/main/java/org/geysermc/floodgate/util/VelocitySkinApplier.java
+++ b/velocity/src/main/java/org/geysermc/floodgate/util/VelocitySkinApplier.java
@@ -29,10 +29,8 @@ import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.util.GameProfile.Property;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.geysermc.floodgate.api.player.FloodgatePlayer;
 import org.geysermc.floodgate.skin.SkinApplier;
@@ -53,15 +51,27 @@ public class VelocitySkinApplier implements SkinApplier {
 
     @Override
     public boolean hasSkin(FloodgatePlayer floodgatePlayer) {
-        Optional<Player> player = server.getPlayer(floodgatePlayer.getCorrectUniqueId());
+        Player player = server.getPlayer(floodgatePlayer.getCorrectUniqueId()).orElse(null);
 
-        if (!player.isPresent())
+        if (player == null) {
             return false;
+        }
 
-        List<Property> textures = player.get().getGameProfileProperties().stream()
-                .filter(p -> p.getName().equals("textures"))
-                .collect(Collectors.toList());
+        List<Property> textures = new ArrayList<>();
+        for (Property property : player.getGameProfileProperties()) {
+            if (property.getName().equals("textures")) {
+                textures.add(property);
+            }
+        }
 
-        return !textures.isEmpty() && textures.stream().noneMatch(p -> p.getValue().isEmpty());
+        if (textures.isEmpty()) {
+            return false;
+        }
+        for (Property p : textures) {
+            if (p.getValue().isEmpty()) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/velocity/src/main/java/org/geysermc/floodgate/util/VelocitySkinApplier.java
+++ b/velocity/src/main/java/org/geysermc/floodgate/util/VelocitySkinApplier.java
@@ -25,11 +25,13 @@
 
 package org.geysermc.floodgate.util;
 
+import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.util.GameProfile.Property;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.geysermc.floodgate.api.player.FloodgatePlayer;
@@ -44,17 +46,22 @@ public class VelocitySkinApplier implements SkinApplier {
     public void applySkin(FloodgatePlayer floodgatePlayer, SkinData skinData) {
         server.getPlayer(floodgatePlayer.getCorrectUniqueId()).ifPresent(player -> {
             List<Property> properties = new ArrayList<>(player.getGameProfileProperties());
-
-            List<Property> textures = properties.stream()
-                    .filter(p -> p.getName().equals("textures"))
-                    .collect(Collectors.toList());
-
-            if (!textures.isEmpty() && textures.stream().noneMatch(p -> p.getValue().isEmpty())) {
-                return;
-            }
-
             properties.add(new Property("textures", skinData.getValue(), skinData.getSignature()));
             player.setGameProfileProperties(properties);
         });
+    }
+
+    @Override
+    public boolean hasSkin(FloodgatePlayer floodgatePlayer) {
+        Optional<Player> player = server.getPlayer(floodgatePlayer.getCorrectUniqueId());
+
+        if (!player.isPresent())
+            return false;
+
+        List<Property> textures = player.get().getGameProfileProperties().stream()
+                .filter(p -> p.getName().equals("textures"))
+                .collect(Collectors.toList());
+
+        return !textures.isEmpty() && textures.stream().noneMatch(p -> p.getValue().isEmpty());
     }
 }


### PR DESCRIPTION
When applying skins to Floodgate players there is a chance of overwriting a skin that another plugin intentionally applied. With this change, all SkinAppliers now check to make sure a player has an empty or null skin before applying a skin to them. This prevents Floodgate from applying a Bedrock skin over a skin that was already set by another plugin. 