### PR TITLE
Fix checking for existing skins on non-Paper Spigot

### DIFF
--- a/spigot/src/main/java/org/geysermc/floodgate/pluginmessage/SpigotSkinApplier.java
+++ b/spigot/src/main/java/org/geysermc/floodgate/pluginmessage/SpigotSkinApplier.java
@@ -25,7 +25,6 @@
 
 package org.geysermc.floodgate.pluginmessage;
 
-import com.destroystokyo.paper.profile.ProfileProperty;
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import com.mojang.authlib.properties.PropertyMap;
@@ -63,11 +62,16 @@ public final class SpigotSkinApplier implements SkinApplier {
             return false;
         }
 
-        for (ProfileProperty property : player.getPlayerProfile().getProperties()) {
-            if (property.getName().equals("textures")) {
-                if (!property.getValue().isEmpty()) {
-                    return true;
-                }
+        GameProfile profile = ReflectionUtils.castedInvoke(player, ClassNames.GET_PROFILE_METHOD);
+        if (profile == null) {
+            throw new IllegalStateException("The GameProfile cannot be null! " + player.getName());
+        }
+
+        // Need to be careful here - getProperties() returns an authlib PropertyMap, which extends
+        // MultiMap from Guava. Floodgate relocates Guava.
+        for (Property textures : profile.getProperties().get("textures")) {
+            if (!textures.getValue().isEmpty()) {
+                return true;
             }
         }
         return false;


### PR DESCRIPTION
`Player#.getPlayerProfile()` is from Paper, which resulted in this: https://api.mclo.gs/1/raw/O2YKpkY

This gets the gameprofile properties the same way that the applySkin method does. Some debugging with these changes, of before and after applying a skin: https://api.mclo.gs/1/raw/Mm6XRrI