### PR TITLE
Use UTF-8 for language files

### DIFF
--- a/core/src/main/java/org/geysermc/floodgate/util/Utils.java
+++ b/core/src/main/java/org/geysermc/floodgate/util/Utils.java
@@ -75,7 +75,7 @@ public class Utils {
             if (is == null) {
                 return null;
             }
-            properties.load(is);
+            properties.load(new InputStreamReader(is, StandardCharsets.UTF_8));
         } catch (IOException e) {
             throw new AssertionError("Failed to read properties file", e);
         }


### PR DESCRIPTION
Languages like ru_RU don't work because they have specific characters, and your files are encoded in UTF-8, but it reads them as ISO 8859-1