### PR TITLE
Eclipse Java Language Server compatibility

### DIFF
--- a/build-logic/src/main/kotlin/floodgate.generate-templates.gradle.kts
+++ b/build-logic/src/main/kotlin/floodgate.generate-templates.gradle.kts
@@ -62,8 +62,6 @@ fun Project.configureIdeSync(vararg generateAllTasks: TaskProvider<Task>) {
             }
         }
     }
-
-    //todo wasn't able to find something for VS(Code)
 }
 
 inline fun <reified T : Any> ExtensionContainer.findByType(noinline action: T.() -> Unit) {

--- a/bungee/build.gradle.kts
+++ b/bungee/build.gradle.kts
@@ -1,3 +1,11 @@
+import org.gradle.plugins.ide.eclipse.model.AccessRule
+import org.gradle.plugins.ide.eclipse.model.AbstractClasspathEntry
+
+plugins {
+    // suppress unsafe access errors for eclipse
+    id("eclipse")
+}
+
 var bungeeCommit = "ff5727c"
 var gsonVersion = "2.8.0"
 var guavaVersion = "21.0"
@@ -18,3 +26,26 @@ provided("com.github.SpigotMC.BungeeCord", "bungeecord-proxy", bungeeCommit)
 provided("com.google.code.gson", "gson", gsonVersion)
 provided("com.google.guava", "guava", guavaVersion)
 provided("org.yaml", "snakeyaml", Versions.snakeyamlVersion)
+
+// found how to do this here https://github.com/JFormDesigner/markdown-writer-fx/blob/main/build.gradle.kts
+eclipse {
+	classpath {
+		file {
+			whenMerged.add( object: Action<org.gradle.plugins.ide.eclipse.model.Classpath> {
+				override fun execute( classpath: org.gradle.plugins.ide.eclipse.model.Classpath ) {
+					val jre = classpath.entries.find {
+						it is AbstractClasspathEntry &&
+							it.path.contains("org.eclipse.jdt.launching.JRE_CONTAINER")
+					} as AbstractClasspathEntry
+
+					// make sun.misc accessible in Eclipse project
+					// (when refreshing Gradle project in buildship)
+					jre.accessRules.add(AccessRule("accessible", "sun/misc/**"))
+
+					// remove trailing slash from jre path
+					if (jre.path.endsWith("/")) jre.path = jre.path.substring(0, jre.path.length - 1)
+				}
+			} )
+		}
+	}
+}

--- a/database/mongo/build.gradle.kts
+++ b/database/mongo/build.gradle.kts
@@ -1,3 +1,8 @@
+plugins {
+    // allow resolution of compileOnlyApi dependencies in Eclipse
+    id("eclipse")
+}
+
 val mongoClientVersion = "4.4.1"
 
 dependencies {
@@ -9,3 +14,10 @@ description = "The Floodgate database extension for MongoDB"
 
 relocate("com.mongodb")
 relocate("org.bson")
+
+eclipse {
+    classpath {
+    	configurations.compileOnlyApi.get().setCanBeResolved(true)
+        plusConfigurations.add( configurations.compileOnlyApi.get() )
+   	}
+}

--- a/database/mysql/build.gradle.kts
+++ b/database/mysql/build.gradle.kts
@@ -1,3 +1,8 @@
+plugins {
+    // allow resolution of compileOnlyApi dependencies in Eclipse
+    id("eclipse")
+}
+
 val mysqlClientVersion = "8.0.30"
 val hikariVersion = "4.0.3"
 
@@ -10,3 +15,10 @@ dependencies {
 description = "The Floodgate database extension for MySQL"
 
 relocate("org.mariadb")
+
+eclipse {
+    classpath {
+    	configurations.compileOnlyApi.get().setCanBeResolved(true)
+        plusConfigurations.add( configurations.compileOnlyApi.get() )
+   	}
+}

--- a/database/sqlite/build.gradle.kts
+++ b/database/sqlite/build.gradle.kts
@@ -1,3 +1,8 @@
+plugins {
+    // allow resolution of compileOnlyApi dependencies in Eclipse
+    id("eclipse")
+}
+
 val sqliteJdbcVersion = "3.36.0.3"
 
 dependencies {
@@ -6,3 +11,10 @@ dependencies {
 }
 
 description = "The Floodgate database extension for SQLite"
+
+eclipse {
+    classpath {
+    	configurations.compileOnlyApi.get().setCanBeResolved(true)
+        plusConfigurations.add( configurations.compileOnlyApi.get() )
+   	}
+}


### PR DESCRIPTION
Modifies kts files to use Gradle eclipse plugin for compatibility with Eclipse/VSCode
Due to the annotation processor, it should be noted that `./gradlew build` must be ran once to build the annotation processor.