### PR TITLE
Localize floodgate.core.not_linked

### DIFF
--- a/core/src/main/java/org/geysermc/floodgate/module/CommonModule.java
+++ b/core/src/main/java/org/geysermc/floodgate/module/CommonModule.java
@@ -69,6 +69,7 @@ import org.geysermc.floodgate.pluginmessage.PluginMessageManager;
 import org.geysermc.floodgate.skin.SkinUploadManager;
 import org.geysermc.floodgate.util.Constants;
 import org.geysermc.floodgate.util.HttpClient;
+import org.geysermc.floodgate.util.LanguageManager;
 
 @RequiredArgsConstructor
 public class CommonModule extends AbstractModule {
@@ -165,10 +166,11 @@ public class CommonModule extends AbstractModule {
             FloodgateConfig config,
             SkinUploadManager skinUploadManager,
             @Named("playerAttribute") AttributeKey<FloodgatePlayer> playerAttribute,
-            FloodgateLogger logger) {
+            FloodgateLogger logger,
+            LanguageManager languageManager) {
 
         return new FloodgateHandshakeHandler(handshakeHandlers, api, cipher, config,
-                skinUploadManager, playerAttribute, logger);
+                skinUploadManager, playerAttribute, logger, languageManager);
     }
 
     @Provides

--- a/core/src/main/java/org/geysermc/floodgate/player/FloodgateHandshakeHandler.java
+++ b/core/src/main/java/org/geysermc/floodgate/player/FloodgateHandshakeHandler.java
@@ -53,6 +53,7 @@ import org.geysermc.floodgate.crypto.FloodgateCipher;
 import org.geysermc.floodgate.skin.SkinUploadManager;
 import org.geysermc.floodgate.util.BedrockData;
 import org.geysermc.floodgate.util.InvalidFormatException;
+import org.geysermc.floodgate.util.LanguageManager;
 import org.geysermc.floodgate.util.LinkedPlayer;
 import org.geysermc.floodgate.util.Utils;
 
@@ -64,6 +65,7 @@ public final class FloodgateHandshakeHandler {
     private final SkinUploadManager skinUploadManager;
     private final AttributeKey<FloodgatePlayer> playerAttribute;
     private final FloodgateLogger logger;
+    private final LanguageManager languageManager;
 
     public FloodgateHandshakeHandler(
             HandshakeHandlersImpl handshakeHandlers,
@@ -72,7 +74,8 @@ public final class FloodgateHandshakeHandler {
             FloodgateConfig config,
             SkinUploadManager skinUploadManager,
             AttributeKey<FloodgatePlayer> playerAttribute,
-            FloodgateLogger logger) {
+            FloodgateLogger logger,
+            LanguageManager languageManager) {
 
         this.handshakeHandlers = handshakeHandlers;
         this.api = api;
@@ -81,6 +84,7 @@ public final class FloodgateHandshakeHandler {
         this.skinUploadManager = skinUploadManager;
         this.playerAttribute = playerAttribute;
         this.logger = logger;
+        this.languageManager = languageManager;
     }
 
     /**
@@ -211,7 +215,9 @@ public final class FloodgateHandshakeHandler {
                     linkedPlayer != null ? linkedPlayer.clone() : null, hostname);
 
             if (config.getPlayerLink().isRequireLink() && linkedPlayer == null) {
-                handshakeData.setDisconnectReason("floodgate.core.not_linked");
+                String reason = languageManager.getString("floodgate.core.not_linked",
+                        bedrockData.getLanguageCode());
+                handshakeData.setDisconnectReason(reason);
             }
 
             handshakeHandlers.callHandshakeHandlers(handshakeData);

--- a/core/src/main/java/org/geysermc/floodgate/player/FloodgateHandshakeHandler.java
+++ b/core/src/main/java/org/geysermc/floodgate/player/FloodgateHandshakeHandler.java
@@ -52,6 +52,7 @@ import org.geysermc.floodgate.config.FloodgateConfig;
 import org.geysermc.floodgate.crypto.FloodgateCipher;
 import org.geysermc.floodgate.skin.SkinUploadManager;
 import org.geysermc.floodgate.util.BedrockData;
+import org.geysermc.floodgate.util.Constants;
 import org.geysermc.floodgate.util.InvalidFormatException;
 import org.geysermc.floodgate.util.LanguageManager;
 import org.geysermc.floodgate.util.LinkedPlayer;
@@ -215,8 +216,11 @@ public final class FloodgateHandshakeHandler {
                     linkedPlayer != null ? linkedPlayer.clone() : null, hostname);
 
             if (config.getPlayerLink().isRequireLink() && linkedPlayer == null) {
-                String reason = languageManager.getString("floodgate.core.not_linked",
-                        bedrockData.getLanguageCode());
+                String reason = languageManager.getString(
+                        "floodgate.core.not_linked",
+                        bedrockData.getLanguageCode(),
+                        Constants.LINK_INFO_URL
+                );
                 handshakeData.setDisconnectReason(reason);
             }
 


### PR DESCRIPTION
Currently, the disconnect reason if linking is required is always `floodgate.core.not_linked`

The translation key still needs to be added to languages.

Fixes #378 (once languages is also updated)