### PR TITLE
Fix injection of LanguageManager/Slf4jFloodgate on Velocity

### DIFF
--- a/velocity/src/main/java/org/geysermc/floodgate/logger/Slf4jFloodgateLogger.java
+++ b/velocity/src/main/java/org/geysermc/floodgate/logger/Slf4jFloodgateLogger.java
@@ -39,10 +39,11 @@ import org.slf4j.Logger;
 @Singleton
 public final class Slf4jFloodgateLogger implements FloodgateLogger {
     @Inject private Logger logger;
-    @Inject private LanguageManager languageManager;
+    private LanguageManager languageManager;
 
     @Inject
-    private void init(FloodgateConfig config) {
+    private void init(LanguageManager languageManager, FloodgateConfig config) {
+        this.languageManager = languageManager;
         if (config.isDebug() && !logger.isDebugEnabled()) {
             Configurator.setLevel(logger.getName(), Level.DEBUG);
         }


### PR DESCRIPTION
This only works because of the circular proxy feature provided by Guice

This fix has already been applied to the JavaUtilFloodgateLogger used by Spigot/BungeeCord