### PR TITLE
Check IS_FOLIA silently

### DIFF
--- a/spigot/src/main/java/org/geysermc/floodgate/util/ClassNames.java
+++ b/spigot/src/main/java/org/geysermc/floodgate/util/ClassNames.java
@@ -226,7 +226,7 @@ public class ClassNames {
             }
         }
 
-        IS_FOLIA = ReflectionUtils.getClass(
+        IS_FOLIA = ReflectionUtils.getClassSilently(
                 "io.papermc.paper.threadedregions.scheduler.EntityScheduler"
         ) != null;
     }


### PR DESCRIPTION
If the server is not a Folia server and you try to run the latest version of Floodgate, you get this stack trace:

```
java.lang.ClassNotFoundException: io.papermc.paper.threadedregions.scheduler.EntityScheduler
[20:24:07 WARN]: 	at org.bukkit.plugin.java.PluginClassLoader.loadClass0(PluginClassLoader.java:183)
[20:24:07 WARN]: 	at org.bukkit.plugin.java.PluginClassLoader.loadClass(PluginClassLoader.java:150)
[20:24:07 WARN]: 	at java.base/java.lang.ClassLoader.loadClass(Unknown Source)
[20:24:07 WARN]: 	at java.base/java.lang.Class.forName0(Native Method)
[20:24:07 WARN]: 	at java.base/java.lang.Class.forName(Unknown Source)
[20:24:07 WARN]: 	at floodgate-spigot.jar//org.geysermc.floodgate.util.ReflectionUtils.getClass(ReflectionUtils.java:87)
[20:24:07 WARN]: 	at floodgate-spigot.jar//org.geysermc.floodgate.util.ClassNames.<clinit>(ClassNames.java:229)
[20:24:07 WARN]: 	at floodgate-spigot.jar//org.geysermc.floodgate.inject.spigot.SpigotInjector.getServerConnection(SpigotInjector.java:173)
[20:24:07 WARN]: 	at floodgate-spigot.jar//org.geysermc.floodgate.inject.spigot.SpigotInjector.inject(SpigotInjector.java:62)
[20:24:07 WARN]: 	at floodgate-spigot.jar//org.geysermc.floodgate.FloodgatePlatform.enable(FloodgatePlatform.java:71)
[20:24:07 WARN]: 	at floodgate-spigot.jar//org.geysermc.floodgate.SpigotPlugin.onEnable(SpigotPlugin.java:71)
[20:24:07 WARN]: 	at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:279)
[20:24:07 WARN]: 	at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.enablePlugin(PaperPluginInstanceManager.java:192)
[20:24:07 WARN]: 	at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.enablePlugin(PaperPluginManagerImpl.java:104)
[20:24:07 WARN]: 	at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:507)
[20:24:07 WARN]: 	at org.bukkit.craftbukkit.v1_19_R3.CraftServer.enablePlugin(CraftServer.java:555)
[20:24:07 WARN]: 	at org.bukkit.craftbukkit.v1_19_R3.CraftServer.enablePlugins(CraftServer.java:466)
[20:24:07 WARN]: 	at net.minecraft.server.MinecraftServer.loadWorld0(MinecraftServer.java:638)
[20:24:07 WARN]: 	at net.minecraft.server.MinecraftServer.loadLevel(MinecraftServer.java:437)
[20:24:07 WARN]: 	at net.minecraft.server.dedicated.DedicatedServer.e(DedicatedServer.java:308)
[20:24:07 WARN]: 	at net.minecraft.server.MinecraftServer.w(MinecraftServer.java:1104)
[20:24:07 WARN]: 	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:320)
[20:24:07 WARN]: 	at java.base/java.lang.Thread.run(Unknown Source)
```

This PR should check if the class exists, silently, so this stack trace shouldn't be printed to console.