### PR TITLE
Bump bungeecord-proxy commit version

### DIFF
--- a/bungee/build.gradle.kts
+++ b/bungee/build.gradle.kts
@@ -1,4 +1,4 @@
-var bungeeCommit = "dfd847f"
+var bungeeCommit = "9e5ed82"
 var gsonVersion = "2.8.0"
 var guavaVersion = "21.0"
 


### PR DESCRIPTION
This was done blindly without testing

I suspect that the old commit is no longer available on JitPack, causing builds to fail on GitHub Actions but not Jenkins (due to caching)