### PR TITLE
Update Geyser version

### DIFF
--- a/build-logic/src/main/kotlin/Versions.kt
+++ b/build-logic/src/main/kotlin/Versions.kt
@@ -24,7 +24,7 @@
  */
 
 object Versions {
-    const val geyserVersion = "2.1.2-SNAPSHOT"
+    const val geyserVersion = "2.2.0-SNAPSHOT"
     const val cumulusVersion = "1.1.2"
     const val eventsVersion = "1.1-SNAPSHOT"
     const val configUtilsVersion = "1.0-SNAPSHOT"

--- a/build-logic/src/main/kotlin/Versions.kt
+++ b/build-logic/src/main/kotlin/Versions.kt
@@ -24,7 +24,7 @@
  */
 
 object Versions {
-    const val geyserVersion = "2.2.0-SNAPSHOT"
+    const val geyserVersion = "2.2.1-SNAPSHOT"
     const val cumulusVersion = "1.1.2"
     const val eventsVersion = "1.1-SNAPSHOT"
     const val configUtilsVersion = "1.0-SNAPSHOT"


### PR DESCRIPTION
This should fix AesKeyProducer errors that were fixed in https://github.com/GeyserMC/Geyser/commit/6b67e43f8463aa2ea0672d901e587a22a595ed7a