### PR TITLE
Support 1.20.5 Spigot

### DIFF
--- a/bungee/build.gradle.kts
+++ b/bungee/build.gradle.kts
@@ -1,4 +1,4 @@
-var bungeeCommit = "master-SNAPSHOT"
+var bungeeVersion = "1.20-R0.3-SNAPSHOT"
 var gsonVersion = "2.8.0"
 var guavaVersion = "21.0"
 
@@ -16,6 +16,6 @@ relocate("io.leangen.geantyref")
 relocate("org.yaml")
 
 // these dependencies are already present on the platform
-provided("com.github.SpigotMC.BungeeCord", "bungeecord-proxy", bungeeCommit)
+provided("net.md-5", "bungeecord-proxy", bungeeVersion)
 provided("com.google.code.gson", "gson", gsonVersion)
 provided("com.google.guava", "guava", guavaVersion)

--- a/spigot/src/main/java/org/geysermc/floodgate/addon/data/SpigotDataHandler.java
+++ b/spigot/src/main/java/org/geysermc/floodgate/addon/data/SpigotDataHandler.java
@@ -68,9 +68,9 @@ public final class SpigotDataHandler extends CommonDataHandler {
             // 1.20.2 and above
             try {
                 Object[] components = new Object[]{
-                    ClassNames.HANDSHAKE_PORT.get(handshakePacket),
-                    hostname,
                     ClassNames.HANDSHAKE_PROTOCOL.get(handshakePacket),
+                    hostname,
+                    ClassNames.HANDSHAKE_PORT.get(handshakePacket),
                     ClassNames.HANDSHAKE_INTENTION.get(handshakePacket)
                 };
 

--- a/spigot/src/main/java/org/geysermc/floodgate/util/ClassNames.java
+++ b/spigot/src/main/java/org/geysermc/floodgate/util/ClassNames.java
@@ -293,13 +293,22 @@ public class ClassNames {
                     String.class, int.class, CLIENT_INTENT);
             checkNotNull(HANDSHAKE_PACKET_CONSTRUCTOR, "Handshake packet constructor");
 
-            HANDSHAKE_PORT = getField(HANDSHAKE_PACKET, "a");
-            checkNotNull(HANDSHAKE_PORT, "Handshake port");
-            makeAccessible(HANDSHAKE_PORT);
+            Field a = getField(HANDSHAKE_PACKET, "a");
+            checkNotNull(a, "Handshake \"a\" field (protocol version, or stream codec)");
 
-            HANDSHAKE_PROTOCOL = getField(HANDSHAKE_PACKET, "c");
+            if (a.getType().isPrimitive()) { // 1.20.2 - 1.20.4: a is the protocol version (int)
+                HANDSHAKE_PROTOCOL = a;
+                HANDSHAKE_PORT = getField(HANDSHAKE_PACKET, "c");
+            } else { // 1.20.5: a is the stream_codec thing, so everything is shifted
+                HANDSHAKE_PROTOCOL = getField(HANDSHAKE_PACKET, "b");
+                HANDSHAKE_PORT = getField(HANDSHAKE_PACKET, "d");
+            }
+
             checkNotNull(HANDSHAKE_PROTOCOL, "Handshake protocol");
             makeAccessible(HANDSHAKE_PROTOCOL);
+
+            checkNotNull(HANDSHAKE_PORT, "Handshake port");
+            makeAccessible(HANDSHAKE_PORT);
 
             HANDSHAKE_INTENTION = getFieldOfType(HANDSHAKE_PACKET, CLIENT_INTENT);
             checkNotNull(HANDSHAKE_INTENTION, "Handshake intention");


### PR DESCRIPTION
Also:
- fixes flipped protocol-version and port in the handshake_packet
- updates languages to https://github.com/GeyserMC/languages/commit/df599a9bc9d7fce93a586591d6c0d625eefe4463 (last pre-dev string version)
- updates bungee dependency (like dev) to be able to build the project

Tested on Spigot 1.20.5 (with Geyser-Standalone), and Paper 1.20.2/1.20.4 (to still be compatible)

Docs/Sources on the fields: 
1.20.5: https://nms.screamingsandals.org/1.20.5/net/minecraft/network/protocol/handshake/ClientIntentionPacket.html
1.20.2: https://nms.screamingsandals.org/1.20.2/net/minecraft/network/protocol/handshake/ClientIntentionPacket.html