### PR TITLE
Allow Floodgate-Fabric to provide its own TemplateReader

### DIFF
--- a/core/src/main/java/org/geysermc/floodgate/config/ConfigLoader.java
+++ b/core/src/main/java/org/geysermc/floodgate/config/ConfigLoader.java
@@ -33,7 +33,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.geysermc.configutils.ConfigUtilities;
 import org.geysermc.configutils.file.codec.PathFileCodec;
-import org.geysermc.configutils.file.template.ResourceTemplateReader;
+import org.geysermc.configutils.file.template.TemplateReader;
 import org.geysermc.configutils.updater.change.Changes;
 import org.geysermc.floodgate.crypto.FloodgateCipher;
 import org.geysermc.floodgate.crypto.KeyProducer;
@@ -46,6 +46,7 @@ public final class ConfigLoader {
 
     private final KeyProducer keyProducer;
     private final FloodgateCipher cipher;
+    private final TemplateReader reader;
 
     @SuppressWarnings("unchecked")
     public <T extends FloodgateConfig> T load() {
@@ -64,7 +65,7 @@ public final class ConfigLoader {
                 ConfigUtilities.builder()
                         .fileCodec(PathFileCodec.of(dataDirectory))
                         .configFile("config.yml")
-                        .templateReader(ResourceTemplateReader.of(getClass()))
+                        .templateReader(reader)
                         .template(templateFile)
                         .changes(Changes.builder()
                                 .version(1, Changes.versionBuilder()

--- a/core/src/main/java/org/geysermc/floodgate/module/CommonModule.java
+++ b/core/src/main/java/org/geysermc/floodgate/module/CommonModule.java
@@ -40,6 +40,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import lombok.RequiredArgsConstructor;
+import org.geysermc.configutils.file.template.ResourceTemplateReader;
+import org.geysermc.configutils.file.template.TemplateReader;
 import org.geysermc.event.PostOrder;
 import org.geysermc.floodgate.addon.data.HandshakeHandlersImpl;
 import org.geysermc.floodgate.api.FloodgateApi;
@@ -75,6 +77,12 @@ import org.geysermc.floodgate.util.LanguageManager;
 public class CommonModule extends AbstractModule {
     private final EventBus eventBus = new EventBus();
     private final Path dataDirectory;
+    private final TemplateReader reader;
+
+    public CommonModule(Path dataDirectory) {
+        this.dataDirectory = dataDirectory;
+        this.reader = ResourceTemplateReader.of(ConfigLoader.class);
+    }
 
     @Override
     protected void configure() {
@@ -154,7 +162,7 @@ public class CommonModule extends AbstractModule {
             @Named("configClass") Class<? extends FloodgateConfig> configClass,
             KeyProducer producer,
             FloodgateCipher cipher) {
-        return new ConfigLoader(dataDirectory, configClass, producer, cipher);
+        return new ConfigLoader(dataDirectory, configClass, producer, cipher, reader);
     }
 
     @Provides

--- a/core/src/main/java/org/geysermc/floodgate/module/ServerCommonModule.java
+++ b/core/src/main/java/org/geysermc/floodgate/module/ServerCommonModule.java
@@ -29,12 +29,18 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import java.nio.file.Path;
+import org.geysermc.configutils.file.template.TemplateReader;
 import org.geysermc.floodgate.api.SimpleFloodgateApi;
 import org.geysermc.floodgate.config.FloodgateConfig;
 
 public final class ServerCommonModule extends CommonModule {
     public ServerCommonModule(Path dataDirectory) {
         super(dataDirectory);
+    }
+
+    // Used in floodgate-fabric to provide it's own reader implementation
+    public ServerCommonModule(Path dataDirectory, TemplateReader reader) {
+        super(dataDirectory, reader);
     }
 
     @Override


### PR DESCRIPTION
Will be needed to allow Floodgate-Fabric to provide its own reader that uses the FabricLoader api to retrieve asset files from the mod jar instead of using the classloader method for it (which currently causes issues if any other mod also ships a `config.yml` file at the root of the mod, as Fabric shares the class loader across multiple mods)