### PR TITLE
1.21 Spigot support

### DIFF
--- a/build-logic/src/main/kotlin/Versions.kt
+++ b/build-logic/src/main/kotlin/Versions.kt
@@ -33,8 +33,7 @@ object Versions {
     const val guiceVersion = "6.0.0"
     const val nettyVersion = "4.1.49.Final"
     const val snakeyamlVersion = "1.28"
-    // TODO move to cloud release once those have 1.20.5 support
-    const val cloudVersion = "2.0.0-beta.7" // for cloud-minecraft
+    const val cloudVersion = "2.0.0-SNAPSHOT" // for cloud-minecraft
     const val cloudCore = "2.0.0-rc.1"
     const val bstatsVersion = "3.0.2"
 

--- a/spigot/build.gradle.kts
+++ b/spigot/build.gradle.kts
@@ -13,7 +13,9 @@ indra {
 dependencies {
     api(projects.core)
 
-    implementation("org.incendo", "cloud-paper", Versions.cloudVersion)
+    //implementation("org.incendo", "cloud-paper", Versions.cloudVersion)
+    // TODO change back after https://github.com/incendo/cloud-minecraft is merged
+    implementation("com.github.onebeastchris.cloud-minecraft", "cloud-paper", "jitpack-SNAPSHOT")
     // hack to make pre 1.12 work
     implementation("com.google.guava", "guava", guavaVersion)
 

--- a/spigot/src/main/java/org/geysermc/floodgate/module/SpigotCommandModule.java
+++ b/spigot/src/main/java/org/geysermc/floodgate/module/SpigotCommandModule.java
@@ -40,7 +40,7 @@ import org.geysermc.floodgate.player.UserAudience;
 import org.geysermc.floodgate.player.audience.FloodgateSenderMapper;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.execution.ExecutionCoordinator;
-import org.incendo.cloud.paper.PaperCommandManager;
+import org.incendo.cloud.paper.LegacyPaperCommandManager;
 
 @RequiredArgsConstructor
 public final class SpigotCommandModule extends CommandModule {
@@ -56,7 +56,7 @@ public final class SpigotCommandModule extends CommandModule {
     @Singleton
     @SneakyThrows
     public CommandManager<UserAudience> commandManager(CommandUtil commandUtil) {
-        CommandManager<UserAudience> commandManager = new PaperCommandManager<>(
+        CommandManager<UserAudience> commandManager = new LegacyPaperCommandManager<>(
                 plugin,
                 ExecutionCoordinator.simpleCoordinator(),
                 new FloodgateSenderMapper<>(commandUtil)


### PR DESCRIPTION
Closes https://github.com/GeyserMC/Floodgate/issues/520

Targets a jitpacked branch of cloud; specifically, this PR: https://github.com/Incendo/cloud-minecraft/pull/78
(that's not fully true; it targets https://github.com/onebeastchris/cloud-minecraft/tree/jitpack as it would otherwise choose java 8 and not build.)