### PR TITLE
Update cloud to 2.0.0-beta.9

### DIFF
--- a/build-logic/src/main/kotlin/Versions.kt
+++ b/build-logic/src/main/kotlin/Versions.kt
@@ -33,8 +33,8 @@ object Versions {
     const val guiceVersion = "6.0.0"
     const val nettyVersion = "4.1.49.Final"
     const val snakeyamlVersion = "1.28"
-    const val cloudVersion = "2.0.0-SNAPSHOT" // for cloud-minecraft
-    const val cloudCore = "2.0.0-rc.1"
+    const val cloudVersion = "2.0.0-beta.9" // for cloud-minecraft
+    const val cloudCore = "2.0.0-rc.2"
     const val bstatsVersion = "3.0.2"
 
     const val javaWebsocketVersion = "1.5.2"

--- a/spigot/build.gradle.kts
+++ b/spigot/build.gradle.kts
@@ -13,9 +13,7 @@ indra {
 dependencies {
     api(projects.core)
 
-    //implementation("org.incendo", "cloud-paper", Versions.cloudVersion)
-    // TODO change back after https://github.com/incendo/cloud-minecraft is merged
-    implementation("com.github.onebeastchris.cloud-minecraft", "cloud-paper", "jitpack-SNAPSHOT")
+    implementation("org.incendo", "cloud-paper", Versions.cloudVersion)
     // hack to make pre 1.12 work
     implementation("com.google.guava", "guava", guavaVersion)
 


### PR DESCRIPTION
Just for consistency with Geyser's cloud changes - it also allows us to not rely on jitpack (https://github.com/GeyserMC/Floodgate/pull/521)