### PR TITLE
Check if channel is open before injecting

### DIFF
--- a/bungee/src/main/java/org/geysermc/floodgate/inject/bungee/BungeeInjector.java
+++ b/bungee/src/main/java/org/geysermc/floodgate/inject/bungee/BungeeInjector.java
@@ -91,6 +91,7 @@ public final class BungeeInjector extends CommonPlatformInjector {
             ChannelInitializer<Channel> wrapper = new ChannelInitializer<Channel>() {
                 @Override
                 protected void initChannel(Channel channel) {
+                    // Check if the channel is open, see #547
                     if (!channel.isOpen()) {
                         return;
                     }

--- a/bungee/src/main/java/org/geysermc/floodgate/inject/bungee/BungeeInjector.java
+++ b/bungee/src/main/java/org/geysermc/floodgate/inject/bungee/BungeeInjector.java
@@ -91,6 +91,9 @@ public final class BungeeInjector extends CommonPlatformInjector {
             ChannelInitializer<Channel> wrapper = new ChannelInitializer<Channel>() {
                 @Override
                 protected void initChannel(Channel channel) {
+                    if (!channel.isOpen()) {
+                        return;
+                    }
                     ReflectionUtils.invoke(original, initChannelMethod, channel);
                     channel.pipeline().addBefore(
                             PipelineUtils.FRAME_DECODER, BUNGEE_INIT,


### PR DESCRIPTION
Some forks like FlameCord have integrated anti-bot features to block connections early. 

By default, Floodgate runs anyways, which not only makes bot attacks affect the server when Floodgate is instaled, but also generate an exception. 

This fixes the issue.