### PR TITLE
Fix of #547

### DIFF
--- a/bungee/src/main/java/org/geysermc/floodgate/inject/bungee/BungeeInjector.java
+++ b/bungee/src/main/java/org/geysermc/floodgate/inject/bungee/BungeeInjector.java
@@ -91,11 +91,19 @@ public final class BungeeInjector extends CommonPlatformInjector {
             ChannelInitializer<Channel> wrapper = new ChannelInitializer<Channel>() {
                 @Override
                 protected void initChannel(Channel channel) {
-                    // Check if the channel is open, see #547
-                    if (!channel.isOpen()) {
+                    /*
+                        Check if the channel is open, see #547
+                        Moved bottom ReflectionUtils.invoke()
+                        Here is always true and it do not work
+                     */
+                    ReflectionUtils.invoke(original, initChannelMethod, channel);
+
+                    // Fix of #547 (after testing)
+                    if (!channel.isOpen())
+                    {
                         return;
                     }
-                    ReflectionUtils.invoke(original, initChannelMethod, channel);
+
                     channel.pipeline().addBefore(
                             PipelineUtils.FRAME_DECODER, BUNGEE_INIT,
                             new BungeeClientToProxyInjectInitializer(BungeeInjector.this)

--- a/bungee/src/main/java/org/geysermc/floodgate/inject/bungee/BungeeInjector.java
+++ b/bungee/src/main/java/org/geysermc/floodgate/inject/bungee/BungeeInjector.java
@@ -91,14 +91,8 @@ public final class BungeeInjector extends CommonPlatformInjector {
             ChannelInitializer<Channel> wrapper = new ChannelInitializer<Channel>() {
                 @Override
                 protected void initChannel(Channel channel) {
-                    /*
-                        Check if the channel is open, see #547
-                        Moved bottom ReflectionUtils.invoke()
-                        Here is always true and it do not work
-                     */
                     ReflectionUtils.invoke(original, initChannelMethod, channel);
-
-                    // Fix of #547 (after testing)
+                    // Check if the channel is open, see #547
                     if (!channel.isOpen()) {
                         return;
                     }

--- a/bungee/src/main/java/org/geysermc/floodgate/inject/bungee/BungeeInjector.java
+++ b/bungee/src/main/java/org/geysermc/floodgate/inject/bungee/BungeeInjector.java
@@ -99,8 +99,7 @@ public final class BungeeInjector extends CommonPlatformInjector {
                     ReflectionUtils.invoke(original, initChannelMethod, channel);
 
                     // Fix of #547 (after testing)
-                    if (!channel.isOpen())
-                    {
+                    if (!channel.isOpen()) {
                         return;
                     }
 


### PR DESCRIPTION
The previous commit check if channel is opened but in that point the channel is always opened.
The ReflectionUtils.invoke() can become closed.

Solution finded with debugging and testing. I print when channel become closed and now work correctly