### PR TITLE
check if channel is active before injecting on velocity

### DIFF
--- a/velocity/src/main/java/org/geysermc/floodgate/inject/velocity/VelocityInjector.java
+++ b/velocity/src/main/java/org/geysermc/floodgate/inject/velocity/VelocityInjector.java
@@ -100,10 +100,11 @@ public final class VelocityInjector extends CommonPlatformInjector {
 
         @Override
         protected void initChannel(Channel channel) {
+            invoke(original, initChannel, channel);
+            // Was closed by another handler?
             if (!channel.isActive()) {
                 return;
             }
-            invoke(original, initChannel, channel);
 
             injector.injectAddonsCall(channel, proxyToServer);
             injector.addInjectedClient(channel);


### PR DESCRIPTION
This fixes anti-bot support with forks like [VeloFlame](https://veloflame.com/) that act before Geyser and Floodgate and fixes a critical error during initialization if the channel was closed