### PR TITLE
Resolve race condition when injecting floodgate handler

### DIFF
--- a/spigot/src/main/java/org/geysermc/floodgate/inject/spigot/SpigotInjector.java
+++ b/spigot/src/main/java/org/geysermc/floodgate/inject/spigot/SpigotInjector.java
@@ -110,16 +110,17 @@ public final class SpigotInjector extends CommonPlatformInjector {
         future.channel().pipeline().addFirst("floodgate-init", new ChannelInboundHandlerAdapter() {
             @Override
             public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-                super.channelRead(ctx, msg);
-
                 Channel channel = (Channel) msg;
-                channel.pipeline().addLast(new ChannelInitializer<Channel>() {
+                channel.pipeline().addLast("floodgate-injector", new ChannelInboundHandlerAdapter() {
                     @Override
-                    protected void initChannel(Channel channel) {
-                        injectAddonsCall(channel, false);
-                        addInjectedClient(channel);
+                    public void channelActive(ChannelHandlerContext childCtx) throws Exception {
+                        injectAddonsCall(childCtx.channel(), false);
+                        addInjectedClient(childCtx.channel());
+                        childCtx.pipeline().remove(this);
+                        super.channelActive(childCtx);
                     }
                 });
+                super.channelRead(ctx, msg);
             }
         });
     }


### PR DESCRIPTION
This should resolve a long-standing issue where floodgate-spigot was "late" to the party, especially when used alongside Geyser-Spigot. 

Initial debugging (see this [gist](https://gist.github.com/onebeastchris/40a2e62afe31878580c9a7a5bd24a572) ) shows a case where netty fired `channelActive` before Floodgate finished its injection process.

With Geyser's `use-direct-connection` feature, MCPL receives this `channelActive` call, which resulted in MCPL firing a [`ConnectedEvent`](https://github.com/GeyserMC/MCProtocolLib/blob/576bb9816cd1ded1e8bf7714d0ca9911cbf90c07/protocol/src/main/java/org/geysermc/mcprotocollib/network/session/NetworkSession.java#L277)), which in turn is used by the `ClientListener` to start the [auth process](https://github.com/GeyserMC/MCProtocolLib/blob/576bb9816cd1ded1e8bf7714d0ca9911cbf90c07/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ClientListener.java#L206) by sending a packet that floodgate is supposed to intercept. However, Floodgate wasn't able to due to the injection not being completed in some occurrences at that time.

[Here](https://gist.github.com/onebeastchris/4df8e9c42631a8b9355a028538f9ed69) is a log showing which events are fired with this patch. I've tested it locally and am no longer able to reproduce the issue with this patch - without it, it occurred about once every 4-5 joins.

Resolves https://github.com/GeyserMC/Floodgate/issues/530,
Resolves https://github.com/GeyserMC/Geyser/issues/5086,
Resolves https://github.com/GeyserMC/Geyser/issues/5828,
Resolves https://github.com/GeyserMC/Geyser/issues/5975,
Resolves https://github.com/GeyserMC/Geyser/issues/4403,
likely also https://github.com/GeyserMC/Floodgate/issues/598