### PR TITLE
Enhance websocket robustness and debugging for skin loading

### DIFF
--- a/core/src/main/java/org/geysermc/floodgate/config/FloodgateConfig.java
+++ b/core/src/main/java/org/geysermc/floodgate/config/FloodgateConfig.java
@@ -50,6 +50,7 @@ public class FloodgateConfig implements GenericPostInitializeCallback<ConfigLoad
     private MetricsConfig metrics;
 
     private boolean debug;
+    private boolean skinUploadDebug;
     private int configVersion;
 
 

--- a/core/src/main/java/org/geysermc/floodgate/skin/MinecraftServerSkinFallback.java
+++ b/core/src/main/java/org/geysermc/floodgate/skin/MinecraftServerSkinFallback.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Floodgate
+ */
+
+package org.geysermc.floodgate.skin;
+
+import com.google.gson.JsonObject;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.Objects;
+import org.geysermc.floodgate.api.FloodgateApi;
+import org.geysermc.floodgate.api.event.skin.SkinApplyEvent.SkinData;
+import org.geysermc.floodgate.api.logger.FloodgateLogger;
+import org.geysermc.floodgate.api.player.FloodgatePlayer;
+import org.geysermc.floodgate.api.player.PropertyKey;
+import org.geysermc.floodgate.player.FloodgatePlayerImpl;
+import org.geysermc.floodgate.util.Constants;
+import org.geysermc.floodgate.util.HttpClient;
+import org.geysermc.floodgate.util.MojangUtils;
+
+@Singleton
+final class MinecraftServerSkinFallback {
+    @Inject private FloodgateApi api;
+    @Inject private SkinApplier applier;
+    @Inject private HttpClient httpClient;
+    @Inject private MojangUtils mojangUtils;
+    @Inject private FloodgateLogger logger;
+
+    int applyForSubscription(int subscribeId, String verifyCode, String trigger,
+            boolean skinUploadDebug) {
+        int matchedPlayers = 0;
+
+        for (FloodgatePlayer player : api.getPlayers()) {
+            if (!(player instanceof FloodgatePlayerImpl)) {
+                continue;
+            }
+
+            FloodgatePlayerImpl floodgatePlayer = (FloodgatePlayerImpl) player;
+            if (floodgatePlayer.getSubscribeId() != subscribeId ||
+                    !Objects.equals(floodgatePlayer.getVerifyCode(), verifyCode)) {
+                continue;
+            }
+
+            matchedPlayers++;
+            fetchAndApplyMinecraftServerSkin(floodgatePlayer, trigger, skinUploadDebug);
+        }
+
+        return matchedPlayers;
+    }
+
+    private void fetchAndApplyMinecraftServerSkin(FloodgatePlayer player, String trigger,
+            boolean skinUploadDebug) {
+        if (!player.isLinked()) {
+            fetchAndApplyBedrockSkinFromGlobalApi(player, trigger, skinUploadDebug);
+            return;
+        }
+
+        fetchAndApplyJavaSkinFromMojang(player, trigger, skinUploadDebug);
+        }
+
+        private void fetchAndApplyBedrockSkinFromGlobalApi(FloodgatePlayer player, String trigger,
+            boolean skinUploadDebug) {
+        String xuid = player.getXuid();
+        if (xuid == null || xuid.isEmpty()) {
+            logger.warn("Bedrock fallback couldn't run for {} (trigger={}) because xuid was missing",
+                player.getCorrectUsername(), trigger);
+            return;
+        }
+
+        logSkinDebug(skinUploadDebug,
+            "Triggering Bedrock fallback via global API for player={} xuid={} trigger={}",
+            player.getCorrectUsername(), xuid, trigger);
+
+        httpClient.asyncGet(Constants.GET_BEDROCK_SKIN_URL + xuid, JsonObject.class)
+            .whenComplete((response, throwable) -> {
+                if (throwable != null) {
+                logger.warn("Global API Bedrock skin fallback failed for {} (trigger={}): {}",
+                    player.getCorrectUsername(), trigger, throwable.getMessage());
+                return;
+                }
+
+                if (response == null || !response.isCodeOk()) {
+                int httpCode = response != null ? response.getHttpCode() : -1;
+                logger.warn("Global API Bedrock skin fallback returned HTTP {} for {} (trigger={})",
+                    httpCode, player.getCorrectUsername(), trigger);
+                return;
+                }
+
+                SkinData resolvedSkin = skinDataFromGlobalApiResponse(response.getResponse());
+                if (resolvedSkin == null || isDefaultSkin(resolvedSkin)) {
+                logger.warn("Global API Bedrock skin fallback returned no usable skin for {} (trigger={})",
+                    player.getCorrectUsername(), trigger);
+                return;
+                }
+
+                applyResolvedSkin(player, resolvedSkin, trigger, skinUploadDebug,
+                    "global-api-bedrock");
+            });
+        }
+
+        private void fetchAndApplyJavaSkinFromMojang(FloodgatePlayer player, String trigger,
+            boolean skinUploadDebug) {
+        logSkinDebug(skinUploadDebug,
+            "Triggering Java fallback via Mojang session server for player={} trigger={}",
+                player.getCorrectUsername(), trigger);
+
+        mojangUtils.skinFor(player.getCorrectUniqueId()).whenComplete((skinData, throwable) -> {
+            if (throwable != null) {
+            logger.warn("Mojang session-server fallback failed for {} (trigger={}): {}",
+                        player.getCorrectUsername(), trigger, throwable.getMessage());
+                return;
+            }
+
+            SkinData resolvedSkin = skinData != null ? skinData : SkinDataImpl.DEFAULT_SKIN;
+            if (isDefaultSkin(resolvedSkin)) {
+                if (!player.isLinked()) {
+                    logger.warn("Minecraft session-server fallback returned default skin for unlinked Bedrock player {} (trigger={}). " +
+                                    "Mojang session servers do not provide Bedrock skins; keeping current skin.",
+                            player.getCorrectUsername(), trigger);
+                } else {
+                    logger.warn("Mojang session-server fallback returned default skin for {} (trigger={}). " +
+                                    "Keeping current skin to avoid overriding with Steve/Alex.",
+                            player.getCorrectUsername(), trigger);
+                }
+                return;
+            }
+
+            applyResolvedSkin(player, resolvedSkin, trigger, skinUploadDebug,
+                    "mojang-sessionserver");
+        });
+    }
+
+    private SkinData skinDataFromGlobalApiResponse(JsonObject response) {
+        if (response == null || !response.has("value") || !response.has("signature")) {
+            return null;
+        }
+
+        try {
+            String value = response.get("value").getAsString();
+            String signature = response.get("signature").getAsString();
+            if (value == null || value.isEmpty() || signature == null || signature.isEmpty()) {
+                return null;
+            }
+            return new SkinDataImpl(value, signature);
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private void applyResolvedSkin(FloodgatePlayer player, SkinData resolvedSkin, String trigger,
+            boolean skinUploadDebug, String source) {
+            applier.applySkin(player, resolvedSkin, true);
+            if (!player.isLinked()) {
+                player.addProperty(PropertyKey.SKIN_UPLOADED, resolvedSkin);
+            }
+
+            logSkinDebug(skinUploadDebug,
+                    "Fallback skin applied for player={} trigger={} source={}",
+                    player.getCorrectUsername(), trigger, source);
+    }
+
+    private void logSkinDebug(boolean enabled, String message, Object... args) {
+        if (enabled) {
+            logger.info("[skin-upload-debug] " + message, args);
+        }
+    }
+
+    private boolean isDefaultSkin(SkinData skinData) {
+        return skinData == null ||
+                (Constants.DEFAULT_MINECRAFT_JAVA_SKIN_TEXTURE.equals(skinData.value()) &&
+                        Constants.DEFAULT_MINECRAFT_JAVA_SKIN_SIGNATURE.equals(skinData.signature()));
+    }
+}

--- a/core/src/main/java/org/geysermc/floodgate/skin/SkinUploadManager.java
+++ b/core/src/main/java/org/geysermc/floodgate/skin/SkinUploadManager.java
@@ -30,40 +30,104 @@ import com.google.inject.Singleton;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import java.util.Objects;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import org.geysermc.event.Listener;
 import org.geysermc.event.subscribe.Subscribe;
 import org.geysermc.floodgate.api.FloodgateApi;
+import org.geysermc.floodgate.api.player.FloodgatePlayer;
 import org.geysermc.floodgate.api.logger.FloodgateLogger;
+import org.geysermc.floodgate.config.FloodgateConfig;
 import org.geysermc.floodgate.event.lifecycle.ShutdownEvent;
+import org.geysermc.floodgate.player.FloodgatePlayerImpl;
 
 @Listener
 @Singleton
 public final class SkinUploadManager {
+    private static final int RECONNECT_DELAY_SECONDS = 2;
+
     private final Int2ObjectMap<SkinUploadSocket> connections =
             Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
+    private final ScheduledExecutorService reconnectExecutor =
+            Executors.newSingleThreadScheduledExecutor(task -> {
+                Thread thread = new Thread(task, "floodgate-skin-reconnect");
+                thread.setDaemon(true);
+                return thread;
+            });
+    private volatile boolean shuttingDown;
 
     @Inject private FloodgateApi api;
     @Inject private SkinApplier applier;
+    @Inject private MinecraftServerSkinFallback minecraftServerSkinFallback;
     @Inject private FloodgateLogger logger;
+    @Inject private FloodgateConfig config;
 
     public void addConnectionIfNeeded(int id, String verifyCode) {
-        connections.computeIfAbsent(id, (ignored) -> {
+        connections.computeIfAbsent(id, ignored -> {
             SkinUploadSocket socket =
-                    new SkinUploadSocket(id, verifyCode, this, api, applier, logger);
+                    new SkinUploadSocket(id, verifyCode, this, api, applier,
+                            minecraftServerSkinFallback, logger,
+                        config.isSkinUploadDebug());
             socket.connect();
             return socket;
         });
     }
 
-    public void removeConnection(int id, SkinUploadSocket socket) {
-        connections.remove(id, socket);
+    public void removeConnection(int id, SkinUploadSocket socket, boolean shouldReconnect) {
+        if (!connections.remove(id, socket) || shuttingDown) {
+            return;
+        }
+
+        if (!shouldReconnect) {
+            return;
+        }
+
+        String verifyCode = socket.getVerifyCode();
+        if (!hasMatchingOnlinePlayer(id, verifyCode)) {
+            return;
+        }
+
+        reconnectExecutor.schedule(() -> {
+            if (shuttingDown || !hasMatchingOnlinePlayer(id, verifyCode)) {
+                return;
+            }
+            addConnectionIfNeeded(id, verifyCode);
+        }, RECONNECT_DELAY_SECONDS, TimeUnit.SECONDS);
+    }
+
+    void scheduleRetry(Runnable task, long delay, TimeUnit unit) {
+        reconnectExecutor.schedule(() -> {
+            if (!shuttingDown) {
+                task.run();
+            }
+        }, delay, unit);
     }
 
     public void closeAllSockets() {
+        shuttingDown = true;
+        reconnectExecutor.shutdownNow();
+
         for (SkinUploadSocket socket : connections.values()) {
             socket.close();
         }
         connections.clear();
+    }
+
+    private boolean hasMatchingOnlinePlayer(int id, String verifyCode) {
+        for (FloodgatePlayer player : api.getPlayers()) {
+            if (!(player instanceof FloodgatePlayerImpl)) {
+                continue;
+            }
+
+            FloodgatePlayerImpl floodgatePlayer = (FloodgatePlayerImpl) player;
+            if (floodgatePlayer.getSubscribeId() == id &&
+                    Objects.equals(verifyCode, floodgatePlayer.getVerifyCode())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Subscribe

--- a/core/src/main/java/org/geysermc/floodgate/skin/SkinUploadSocket.java
+++ b/core/src/main/java/org/geysermc/floodgate/skin/SkinUploadSocket.java
@@ -139,7 +139,6 @@ final class SkinUploadSocket extends WebSocketClient {
                         subscribersCount, id);
                 break;
             case SKIN_UPLOADED:
-                receivedSkinUploadedEvent = true;
                 String xuid = message.get("xuid").getAsString();
                 if (!message.get("success").getAsBoolean()) {
                     FloodgatePlayer player = api.getPlayer(Utils.getJavaUuid(xuid));
@@ -151,8 +150,13 @@ final class SkinUploadSocket extends WebSocketClient {
                     }
                     logSkinDebug("Skin upload failure payload for xuid {}: {}", xuid, data);
                     triggerMinecraftFallback("uploader-reported-failed-upload");
+                    // Mark the upload response as received after triggering fallback,
+                    // so timeout-based fallback doesn't log a misleading warning.
+                    receivedSkinUploadedEvent = true;
                     return;
                 }
+
+                receivedSkinUploadedEvent = true;
 
                 SkinData skinData = SkinDataImpl.from(message.getAsJsonObject("data"));
                 logSkinDebug("SKIN_UPLOADED success for xuid {} valueLength={} signatureLength={}",

--- a/core/src/main/java/org/geysermc/floodgate/skin/SkinUploadSocket.java
+++ b/core/src/main/java/org/geysermc/floodgate/skin/SkinUploadSocket.java
@@ -28,10 +28,17 @@ package org.geysermc.floodgate.skin;
 import static org.geysermc.floodgate.util.Constants.WEBSOCKET_URL;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 import java.net.ConnectException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLException;
 import lombok.Getter;
 import org.geysermc.floodgate.api.FloodgateApi;
@@ -46,15 +53,23 @@ import org.java_websocket.handshake.ServerHandshake;
 
 final class SkinUploadSocket extends WebSocketClient {
     private static final Gson gson = new Gson();
+    private static final int SKIN_UPLOAD_EVENT_WAIT_SECONDS = 15;
+    private static final Pattern HTTP_STATUS_PATTERN = Pattern.compile(
+            "(?i)status code received:\\s*(\\d{3})|HTTP/\\d\\.\\d\\s+(\\d{3})");
 
     private final SkinUploadManager uploadManager;
     private final FloodgateApi api;
     private final SkinApplier applier;
+    private final MinecraftServerSkinFallback minecraftServerSkinFallback;
     private final FloodgateLogger logger;
+    private final boolean skinUploadDebug;
 
     @Getter private final int id;
     @Getter private final String verifyCode;
     @Getter private int subscribersCount;
+    private volatile boolean receivedSkinUploadedEvent;
+    private volatile boolean shouldReconnect = true;
+    private volatile boolean fallbackTriggered;
 
     public SkinUploadSocket(
             int id,
@@ -62,7 +77,9 @@ final class SkinUploadSocket extends WebSocketClient {
             SkinUploadManager uploadManager,
             FloodgateApi api,
             SkinApplier applier,
-            FloodgateLogger logger
+            MinecraftServerSkinFallback minecraftServerSkinFallback,
+            FloodgateLogger logger,
+            boolean skinUploadDebug
     ) {
         super(getWebsocketUri(id, verifyCode));
         this.id = id;
@@ -70,7 +87,9 @@ final class SkinUploadSocket extends WebSocketClient {
         this.uploadManager = uploadManager;
         this.api = api;
         this.applier = applier;
+        this.minecraftServerSkinFallback = minecraftServerSkinFallback;
         this.logger = logger;
+        this.skinUploadDebug = skinUploadDebug;
     }
 
     private static URI getWebsocketUri(int id, String verifyCode) {
@@ -86,10 +105,18 @@ final class SkinUploadSocket extends WebSocketClient {
     @Override
     public void onOpen(ServerHandshake ignored) {
         setConnectionLostTimeout(11);
+        receivedSkinUploadedEvent = false;
+        shouldReconnect = true;
+        fallbackTriggered = false;
+        logSkinDebug("WebSocket connected for subscribed_to={} endpoint={}", id,
+                sanitizedEndpoint());
+        scheduleMissingSkinUploadWarning();
     }
 
     @Override
     public void onMessage(String data) {
+        logSkinDebug("Incoming websocket payload for subscribed_to={}: {}", id, data);
+
         JsonObject message = gson.fromJson(data, JsonObject.class);
         if (message.has("error")) {
             logger.error("Skin uploader got an error: {}", message.get("error").getAsString());
@@ -99,32 +126,40 @@ final class SkinUploadSocket extends WebSocketClient {
         WebsocketEventType type = WebsocketEventType.fromId(typeId);
         if (type == null) {
             logger.warn("Got unknown type {}. Ensure that Floodgate is up-to-date", typeId);
+            logSkinDebug("Unknown event type {} for payload: {}", typeId, data);
             return;
         }
+
+        logSkinDebug("Received websocket event {} for subscribed_to={}", type, id);
 
         switch (type) {
             case SUBSCRIBER_COUNT:
                 subscribersCount = message.get("subscribers_count").getAsInt();
+                logSkinDebug("Subscriber count updated to {} for subscribed_to={}",
+                        subscribersCount, id);
                 break;
             case SKIN_UPLOADED:
+                receivedSkinUploadedEvent = true;
                 String xuid = message.get("xuid").getAsString();
-                FloodgatePlayer player = api.getPlayer(Utils.getJavaUuid(xuid));
-                if (player != null) {
-                    if (!message.get("success").getAsBoolean()) {
+                if (!message.get("success").getAsBoolean()) {
+                    FloodgatePlayer player = api.getPlayer(Utils.getJavaUuid(xuid));
+                    if (player != null) {
                         logger.info("Failed to upload skin for {} ({})", xuid,
                                 player.getCorrectUsername());
-                        return;
+                    } else {
+                        logger.info("Failed to upload skin for {}", xuid);
                     }
-
-                    SkinData skinData = SkinDataImpl.from(message.getAsJsonObject("data"));
-                    applier.applySkin(player, skinData, false);
-
-                    // legacy stuff,
-                    // will be removed shortly after or during the Floodgate-Geyser integration
-                    if (!player.isLinked()) {
-                        player.addProperty(PropertyKey.SKIN_UPLOADED, skinData);
-                    }
+                    logSkinDebug("Skin upload failure payload for xuid {}: {}", xuid, data);
+                    triggerMinecraftFallback("uploader-reported-failed-upload");
+                    return;
                 }
+
+                SkinData skinData = SkinDataImpl.from(message.getAsJsonObject("data"));
+                logSkinDebug("SKIN_UPLOADED success for xuid {} valueLength={} signatureLength={}",
+                    xuid, skinData.value().length(), skinData.signature().length());
+                logSkinDebug("SKIN_UPLOADED decoded value for xuid {}: {}", xuid,
+                    decodeSkinValuePlainText(skinData.value()));
+                applySkinOrRetry(xuid, skinData, true);
                 break;
             case LOG_MESSAGE:
                 String logMessage = message.get("message").getAsString();
@@ -145,29 +180,134 @@ final class SkinUploadSocket extends WebSocketClient {
                 break;
             default:
                 // we don't handle the remaining types
+                logSkinDebug("No direct handler for websocket event {}. Raw payload: {}", type,
+                        data);
                 break;
         }
     }
 
     @Override
     public void onClose(int code, String reason, boolean remote) {
-        if (reason != null && !reason.isEmpty()) {
-            JsonObject message = gson.fromJson(reason, JsonObject.class);
+        boolean serverSideHttpError = false;
 
-            // info means that the uploader itself did nothing wrong
-            if (message.has("info")) {
-                String info = message.get("info").getAsString();
-                logger.debug("Got disconnected from the skin uploader: {}", info);
-            }
-
-            // error means that the uploader did something wrong
-            if (message.has("error")) {
-                String error = message.get("error").getAsString();
-                logger.info("Got disconnected from the skin uploader: {}", error);
-            }
+        if (reason == null || reason.isEmpty()) {
+            logSkinDebug("WebSocket closed without reason (code={}, remote={})", code, remote);
         }
 
-        uploadManager.removeConnection(id, this);
+        if (reason != null && !reason.isEmpty()) {
+            serverSideHttpError = logCloseReason(code, reason, remote);
+        }
+
+        if (serverSideHttpError) {
+            triggerMinecraftFallback("uploader-http-5xx");
+        }
+
+        uploadManager.removeConnection(id, this, shouldReconnect);
+    }
+
+    private boolean logCloseReason(int code, String reason, boolean remote) {
+        logSkinDebug("WebSocket close reason payload (code={}, remote={}): {}", code, remote,
+                reason);
+        boolean serverSideHttpError = warnIfUploaderServerIsDown(reason);
+        try {
+            JsonElement element = gson.fromJson(reason, JsonElement.class);
+
+            switch (getCloseReasonType(element)) {
+                case OBJECT:
+                    logJsonCloseReason(code, reason, remote, element.getAsJsonObject());
+                    break;
+                case PRIMITIVE:
+                    logger.debug("Got disconnected from the skin uploader (code={}, remote={}) with primitive reason: {}",
+                            code, remote, reason);
+                    break;
+                case ARRAY:
+                    logger.debug("Got disconnected from the skin uploader (code={}, remote={}) with array reason: {}",
+                            code, remote, reason);
+                    break;
+                case NULL:
+                    logger.debug("Got disconnected from the skin uploader (code={}, remote={}) with null reason",
+                            code, remote);
+                    break;
+                default:
+                    logger.debug("Got disconnected from the skin uploader (code={}, remote={}) with non-object reason: {}",
+                            code, remote, reason);
+                    break;
+            }
+        } catch (JsonSyntaxException ignored) {
+            logger.debug("Got disconnected from the skin uploader (code={}, remote={}) with raw reason: {}",
+                    code, remote, reason);
+        }
+
+        return serverSideHttpError;
+    }
+
+    private CloseReasonType getCloseReasonType(JsonElement element) {
+        if (element == null || element.isJsonNull()) {
+            return CloseReasonType.NULL;
+        }
+        if (element.isJsonObject()) {
+            return CloseReasonType.OBJECT;
+        }
+        if (element.isJsonPrimitive()) {
+            return CloseReasonType.PRIMITIVE;
+        }
+        if (element.isJsonArray()) {
+            return CloseReasonType.ARRAY;
+        }
+        return CloseReasonType.UNKNOWN;
+    }
+
+    private void logJsonCloseReason(int code, String reason, boolean remote, JsonObject message) {
+        boolean hasInfo = message.has("info");
+        boolean hasError = message.has("error");
+
+        // info means that the uploader itself did nothing wrong
+        if (hasInfo) {
+            String info = message.get("info").getAsString();
+            updateReconnectPolicy(info, null);
+            logger.debug("Got disconnected from the skin uploader (code={}, remote={}): {}",
+                    code, remote, info);
+        }
+
+        // error means that the uploader did something wrong
+        if (hasError) {
+            String error = message.get("error").getAsString();
+            updateReconnectPolicy(null, error);
+            logger.info("Got disconnected from the skin uploader (code={}, remote={}): {}",
+                    code, remote, error);
+        }
+
+        if (!hasInfo && !hasError) {
+            logger.debug("Got disconnected from the skin uploader (code={}, remote={}) with JSON reason: {}",
+                    code, remote, reason);
+        }
+    }
+
+    private void applySkinOrRetry(String xuid, SkinData skinData, boolean firstTry) {
+        FloodgatePlayer player = api.getPlayer(Utils.getJavaUuid(xuid));
+        if (player == null) {
+            if (firstTry) {
+                // Skin uploads can arrive before the player is added to the API map.
+                logSkinDebug("Player for xuid {} not available yet; scheduling retry", xuid);
+                uploadManager.scheduleRetry(() -> applySkinOrRetry(xuid, skinData, false),
+                        1, TimeUnit.SECONDS);
+            } else {
+                logSkinDebug("Player for xuid {} still missing after retry; skipping skin apply",
+                        xuid);
+            }
+            return;
+        }
+
+        logSkinDebug("Applying skin for xuid {} (player={})", xuid, player.getCorrectUsername());
+        applier.applySkin(player, skinData, false);
+        logSkinDebug("Skin apply invocation completed for xuid {} (player={})", xuid,
+            player.getCorrectUsername());
+
+        // legacy stuff,
+        // will be removed shortly after or during the Floodgate-Geyser integration
+        if (!player.isLinked()) {
+            player.addProperty(PropertyKey.SKIN_UPLOADED, skinData);
+        }
     }
 
     @Override
@@ -176,11 +316,164 @@ final class SkinUploadSocket extends WebSocketClient {
         // they might however help during debugging so we'll log them when debug is enabled
         if (exception instanceof ConnectException || exception instanceof JsonSyntaxException ||
                 exception instanceof SSLException) {
+            if (skinUploadDebug || logger.isDebug()) {
+                logger.error("[skin-upload-debug] WebSocket transient error", exception);
+            }
             if (logger.isDebug()) {
                 logger.error("[debug] Got an error", exception);
             }
             return;
         }
+
+        if (skinUploadDebug) {
+            logger.error("[skin-upload-debug] WebSocket fatal error", exception);
+        }
         logger.error("Got an error", exception);
+    }
+
+    private void logSkinDebug(String message, Object... args) {
+        if (skinUploadDebug) {
+            logger.info("[skin-upload-debug] " + message, args);
+        }
+    }
+
+    private void scheduleMissingSkinUploadWarning() {
+        uploadManager.scheduleRetry(() -> {
+            if (receivedSkinUploadedEvent || !isOpen()) {
+                return;
+            }
+
+            if (skinUploadDebug) {
+                logger.info("[skin-upload-debug] No SKIN_UPLOADED event received after {}s for subscribed_to={} (pending subscribers_count={}). " +
+                                "Trying Minecraft session server fallback.",
+                        SKIN_UPLOAD_EVENT_WAIT_SECONDS, id, subscribersCount);
+            }
+
+            triggerMinecraftFallback("missing-skin-uploaded-event-timeout");
+        }, SKIN_UPLOAD_EVENT_WAIT_SECONDS, TimeUnit.SECONDS);
+    }
+
+    private String sanitizedEndpoint() {
+        URI uri = getURI();
+        if (uri == null) {
+            return "<unknown>";
+        }
+
+        StringBuilder endpoint = new StringBuilder();
+        if (uri.getScheme() != null) {
+            endpoint.append(uri.getScheme()).append("://");
+        }
+        if (uri.getHost() != null) {
+            endpoint.append(uri.getHost());
+        }
+        if (uri.getPort() > -1) {
+            endpoint.append(':').append(uri.getPort());
+        }
+        if (uri.getPath() != null) {
+            endpoint.append(uri.getPath());
+        }
+        endpoint.append("?subscribed_to=").append(id).append("&verify_code=<hidden>");
+        return endpoint.toString();
+    }
+
+    private String decodeSkinValuePlainText(String value) {
+        try {
+            byte[] decoded = Base64.getDecoder().decode(value);
+            return new String(decoded, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException exception) {
+            return "<invalid base64: " + exception.getMessage() + ">";
+        }
+    }
+
+    private void updateReconnectPolicy(String info, String error) {
+        if (info != null && "creator left and there are no uploads left".equalsIgnoreCase(info)) {
+            disableReconnect("creator-disconnected-no-uploads");
+        }
+
+        if (error != null) {
+            String normalized = error.toLowerCase(Locale.ROOT);
+            if (normalized.contains("failed to find the given code in combination with the verify code")) {
+                disableReconnect("invalid-subscribe-or-verify-code");
+            }
+        }
+    }
+
+    private void disableReconnect(String reason) {
+        if (!shouldReconnect) {
+            return;
+        }
+
+        shouldReconnect = false;
+        logSkinDebug("Disabling reconnect for subscribed_to={} due to terminal reason={}", id,
+                reason);
+    }
+
+    private boolean warnIfUploaderServerIsDown(String reason) {
+        Integer statusCode = extractHttpStatusCode(reason);
+        if (statusCode == null || statusCode < 500 || statusCode >= 600) {
+            return false;
+        }
+
+        logger.warn("Skin uploader returned HTTP {}. The upstream skin server may be down or unstable. Reason: {}",
+                statusCode, reason);
+        return true;
+    }
+
+    private Integer extractHttpStatusCode(String reason) {
+        if (reason == null || reason.isEmpty()) {
+            return null;
+        }
+
+        Matcher matcher = HTTP_STATUS_PATTERN.matcher(reason);
+        if (!matcher.find()) {
+            return null;
+        }
+
+        String first = matcher.group(1);
+        String second = matcher.group(2);
+        String value = first != null ? first : second;
+        if (value == null) {
+            return null;
+        }
+
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private void triggerMinecraftFallback(String trigger) {
+        triggerMinecraftFallback(trigger, true);
+    }
+
+    private void triggerMinecraftFallback(String trigger, boolean allowRetry) {
+        if (fallbackTriggered || receivedSkinUploadedEvent) {
+            return;
+        }
+
+        fallbackTriggered = true;
+        int matchedPlayers = minecraftServerSkinFallback.applyForSubscription(
+                id, verifyCode, trigger, skinUploadDebug);
+
+        if (matchedPlayers == 0) {
+            if (allowRetry) {
+                fallbackTriggered = false;
+                uploadManager.scheduleRetry(() -> triggerMinecraftFallback(trigger, false),
+                        1, TimeUnit.SECONDS);
+                return;
+            }
+
+            logger.warn("Could not run Minecraft session-server fallback for subscribed_to={} (trigger={}) because no matching player was found",
+                    id, trigger);
+        }
+    }
+
+    private enum CloseReasonType {
+        OBJECT,
+        PRIMITIVE,
+        ARRAY,
+        NULL,
+        UNKNOWN
     }
 }

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -14,6 +14,11 @@ replace-spaces: true
 # The default locale for Floodgate. By default, Floodgate uses the system locale
 # default-locale: en_US
 
+# Enables extra diagnostics for skin upload websocket traffic.
+# Useful to inspect what Floodgate receives from api.geysermc.org and why skin apply can fail.
+# Keep disabled in production unless you are troubleshooting skin issues.
+skin-upload-debug: false
+
 disconnect:
   # The disconnect message Geyser users should get when connecting
   # to the server with an invalid key

--- a/core/src/main/templates/org/geysermc/floodgate/util/Constants.java
+++ b/core/src/main/templates/org/geysermc/floodgate/util/Constants.java
@@ -46,6 +46,7 @@ public final class Constants {
     public static final String WEBSOCKET_URL = "ws" + API_BASE_URL + "/ws";
     public static final String GET_XUID_URL = "http" + API_BASE_URL + "/v2/xbox/xuid/";
     public static final String GET_GAMERTAG_URL = "http" + API_BASE_URL + "/v2/xbox/gamertag/";
+        public static final String GET_BEDROCK_SKIN_URL = "http" + API_BASE_URL + "/v2/skin/";
     public static final String NEWS_OVERVIEW_URL = "http" + API_BASE_URL + "/v2/news/";
     public static final String GET_BEDROCK_LINK = "http" + API_BASE_URL + "/v2/link/bedrock/";
 

--- a/core/src/main/templates/org/geysermc/floodgate/util/Constants.java
+++ b/core/src/main/templates/org/geysermc/floodgate/util/Constants.java
@@ -46,7 +46,7 @@ public final class Constants {
     public static final String WEBSOCKET_URL = "ws" + API_BASE_URL + "/ws";
     public static final String GET_XUID_URL = "http" + API_BASE_URL + "/v2/xbox/xuid/";
     public static final String GET_GAMERTAG_URL = "http" + API_BASE_URL + "/v2/xbox/gamertag/";
-        public static final String GET_BEDROCK_SKIN_URL = "http" + API_BASE_URL + "/v2/skin/";
+    public static final String GET_BEDROCK_SKIN_URL = "http" + API_BASE_URL + "/v2/skin/";
     public static final String NEWS_OVERVIEW_URL = "http" + API_BASE_URL + "/v2/news/";
     public static final String GET_BEDROCK_LINK = "http" + API_BASE_URL + "/v2/link/bedrock/";
 

--- a/spigot/src/main/java/org/geysermc/floodgate/pluginmessage/SpigotSkinApplier.java
+++ b/spigot/src/main/java/org/geysermc/floodgate/pluginmessage/SpigotSkinApplier.java
@@ -35,7 +35,9 @@ import org.bukkit.entity.Player;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.floodgate.api.event.skin.SkinApplyEvent;
 import org.geysermc.floodgate.api.event.skin.SkinApplyEvent.SkinData;
+import org.geysermc.floodgate.api.logger.FloodgateLogger;
 import org.geysermc.floodgate.api.player.FloodgatePlayer;
+import org.geysermc.floodgate.config.FloodgateConfig;
 import org.geysermc.floodgate.event.EventBus;
 import org.geysermc.floodgate.event.skin.SkinApplyEventImpl;
 import org.geysermc.floodgate.skin.SkinApplier;
@@ -47,9 +49,14 @@ import org.geysermc.floodgate.util.SpigotVersionSpecificMethods;
 public final class SpigotSkinApplier implements SkinApplier {
     @Inject private SpigotVersionSpecificMethods versionSpecificMethods;
     @Inject private EventBus eventBus;
+    @Inject private FloodgateLogger logger;
+    @Inject private FloodgateConfig config;
 
     @Override
     public void applySkin(@NonNull FloodgatePlayer floodgatePlayer, @NonNull SkinData skinData, boolean internal) {
+        logSkinDebug("Starting skin apply for player={} internal={} valueLength={} signatureLength={}",
+                floodgatePlayer.getCorrectUsername(), internal,
+                skinData.value().length(), skinData.signature().length());
         applySkin0(floodgatePlayer, skinData, internal, true);
     }
 
@@ -59,10 +66,15 @@ public final class SpigotSkinApplier implements SkinApplier {
         // player is probably not logged in yet
         if (player == null) {
             if (firstTry) {
+                logSkinDebug("Player {} not online yet; scheduling delayed skin apply retry",
+                        floodgatePlayer.getCorrectUsername());
                 versionSpecificMethods.schedule(
                         () -> applySkin0(floodgatePlayer, skinData, internal, false),
                         10 * 20
                 );
+            } else {
+                logSkinDebug("Player {} still unavailable after delayed retry; skin apply aborted",
+                        floodgatePlayer.getCorrectUsername());
             }
             return;
         }
@@ -76,29 +88,41 @@ public final class SpigotSkinApplier implements SkinApplier {
         // Need to be careful here - getProperties() returns an authlib PropertyMap, which extends
         // MultiMap from Guava. Floodgate relocates Guava.
         SkinData currentSkin = versionSpecificMethods.currentSkin(profile);
+        logSkinDebug("Current skin for {} present={}", player.getName(), currentSkin != null);
 
         SkinApplyEvent event = new SkinApplyEventImpl(floodgatePlayer, currentSkin, skinData);
         event.setCancelled(!internal && floodgatePlayer.isLinked());
+        logSkinDebug("Skin event initial cancelled={} (linked={} internal={})",
+                event.isCancelled(), floodgatePlayer.isLinked(), internal);
 
         eventBus.fire(event);
+        logSkinDebug("Skin event after listeners cancelled={} for {}",
+                event.isCancelled(), player.getName());
 
         if (event.isCancelled()) {
+            logSkinDebug("Skin apply cancelled for {} by event pipeline", player.getName());
             return;
         }
 
         if (ClassNames.GAME_PROFILE_FIELD != null) {
+            logSkinDebug("Applying skin through immutable GameProfile path for {}", player.getName());
             replaceSkin(player, profile, event.newSkin());
         } else {
             // We're on a version with mutable GameProfiles
+            logSkinDebug("Applying skin through mutable GameProfile path for {}", player.getName());
             replaceSkinOld(profile.getProperties(), event.newSkin());
         }
 
         versionSpecificMethods.maybeSchedule(() -> {
+            int refreshedViewers = 0;
             for (Player p : Bukkit.getOnlinePlayers()) {
                 if (!p.equals(player) && p.canSee(player)) {
                     versionSpecificMethods.hideAndShowPlayer(p, player);
+                    refreshedViewers++;
                 }
             }
+            logSkinDebug("Completed hide/show refresh for {} viewers of {}", refreshedViewers,
+                    player.getName());
         });
     }
 
@@ -113,5 +137,11 @@ public final class SpigotSkinApplier implements SkinApplier {
         properties.removeAll("textures");
         Property property = new Property("textures", skinData.value(), skinData.signature());
         properties.put("textures", property);
+    }
+
+    private void logSkinDebug(String message, Object... args) {
+        if (config.isSkinUploadDebug()) {
+            logger.info("[skin-upload-debug] " + message, args);
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the skin upload system, focusing on robustness, debugging, and fallback handling for Minecraft skin uploads. The most important changes are the addition of a fallback mechanism for skin uploads, enhanced debugging capabilities, and improved reconnection logic for the skin upload socket.

### Skin Upload Fallback Handling

* Added a new `MinecraftServerSkinFallback` class to handle fallback skin application when the primary skin upload fails or encounters errors. This includes fetching skins from Mojang or a global API and applying them to players as needed. (`core/src/main/java/org/geysermc/floodgate/skin/MinecraftServerSkinFallback.java`)
* Integrated the fallback mechanism into the skin upload socket, triggering fallback scenarios such as HTTP errors or failed upload events. (`core/src/main/java/org/geysermc/floodgate/skin/SkinUploadSocket.java`)

### Debugging Enhancements

* Introduced a new `skinUploadDebug` configuration option to enable detailed logging for skin upload events and fallback operations. (`core/src/main/java/org/geysermc/floodgate/config/FloodgateConfig.java`)
* Added extensive debug logging throughout the skin upload socket lifecycle, including connection events, incoming payloads, event handling, and skin application attempts. (`core/src/main/java/org/geysermc/floodgate/skin/SkinUploadSocket.java`) [[1]](diffhunk://#diff-62dc9afc11832eab049819a61cf9c5ad9f4f0ed3e34e22ffa97ab614ae21630cR108-R119) [[2]](diffhunk://#diff-62dc9afc11832eab049819a61cf9c5ad9f4f0ed3e34e22ffa97ab614ae21630cR129-R162)

### Robustness and Reconnection Logic

* Improved reconnection logic for skin upload sockets, including scheduled retries and checks for matching online players before attempting reconnection. (`core/src/main/java/org/geysermc/floodgate/skin/SkinUploadManager.java`)
* Enhanced handling of websocket close events, including parsing and logging of close reasons, and triggering fallback as needed based on detected server-side errors. (`core/src/main/java/org/geysermc/floodgate/skin/SkinUploadSocket.java`)

### Codebase Improvements

* Refactored the skin upload socket to support new fallback and debug features, and improved handling of skin upload events, including retry logic when players are not immediately available. (`core/src/main/java/org/geysermc/floodgate/skin/SkinUploadSocket.java`) [[1]](diffhunk://#diff-62dc9afc11832eab049819a61cf9c5ad9f4f0ed3e34e22ffa97ab614ae21630cR56-R92) [[2]](diffhunk://#diff-62dc9afc11832eab049819a61cf9c5ad9f4f0ed3e34e22ffa97ab614ae21630cR183-R310)

### Dependency and Utility Additions

* Added new imports and utility code to support fallback, debug logging, and scheduled tasks for skin upload management. (`core/src/main/java/org/geysermc/floodgate/skin/SkinUploadManager.java`, `core/src/main/java/org/geysermc/floodgate/skin/SkinUploadSocket.java`) [[1]](diffhunk://#diff-7f8ed34aa06436cd783aa4f4498dd13531bf564634e87d226d546daad6dea947R33-R132) [[2]](diffhunk://#diff-62dc9afc11832eab049819a61cf9c5ad9f4f0ed3e34e22ffa97ab614ae21630cR31-R41)

These changes collectively make the skin upload system more resilient to failures, easier to debug, and capable of gracefully handling edge cases where skin uploads may not succeed through the primary method.

### Issues it addresses

Fixes #655 
Fixes #182 