### PR TITLE
Support optional online-mode auth for Bedrock players

### DIFF
--- a/bungee/src/main/java/org/geysermc/floodgate/listener/BungeeListener.java
+++ b/bungee/src/main/java/org/geysermc/floodgate/listener/BungeeListener.java
@@ -27,12 +27,15 @@ package org.geysermc.floodgate.listener;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import io.netty.channel.Channel;
 import io.netty.util.AttributeKey;
 import java.lang.reflect.Field;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import net.md_5.bungee.api.connection.PendingConnection;
 import net.md_5.bungee.api.event.LoginEvent;
 import net.md_5.bungee.api.event.PlayerDisconnectEvent;
@@ -47,7 +50,9 @@ import net.md_5.bungee.netty.ChannelWrapper;
 import org.geysermc.floodgate.api.ProxyFloodgateApi;
 import org.geysermc.floodgate.api.logger.FloodgateLogger;
 import org.geysermc.floodgate.api.player.FloodgatePlayer;
+import org.geysermc.floodgate.config.ProxyFloodgateConfig;
 import org.geysermc.floodgate.pluginmessage.channel.FormChannel;
+import org.geysermc.floodgate.player.FloodgatePlayerImpl;
 import org.geysermc.floodgate.skin.SkinApplier;
 import org.geysermc.floodgate.skin.SkinDataImpl;
 import org.geysermc.floodgate.util.LanguageManager;
@@ -59,6 +64,12 @@ public final class BungeeListener implements Listener {
     private static final Field CHANNEL_WRAPPER;
     private static final Field PLAYER_NAME;
 
+    private final Cache<PendingConnection, FloodgatePlayer> playerCache =
+            CacheBuilder.newBuilder()
+                    .maximumSize(500)
+                    .expireAfterAccess(20, TimeUnit.SECONDS)
+                    .build();
+
     static {
         CHANNEL_WRAPPER =
                 ReflectionUtils.getFieldOfType(InitialHandler.class, ChannelWrapper.class);
@@ -69,6 +80,7 @@ public final class BungeeListener implements Listener {
     }
 
     @Inject private Plugin plugin;
+    @Inject private ProxyFloodgateConfig config;
     @Inject private ProxyFloodgateApi api;
     @Inject private LanguageManager languageManager;
     @Inject private FloodgateLogger logger;
@@ -107,9 +119,13 @@ public final class BungeeListener implements Listener {
 
         FloodgatePlayer player = channel.attr(playerAttribute).get();
         if (player != null) {
-            connection.setOnlineMode(false);
-            connection.setUniqueId(player.getCorrectUniqueId());
-            ReflectionUtils.setValue(connection, PLAYER_NAME, player.getCorrectUsername());
+            if (config.isAllowOnlineModeAuthentication()) {
+                playerCache.put(connection, player);
+            } else {
+                connection.setOnlineMode(false);
+                connection.setUniqueId(player.getCorrectUniqueId());
+                ReflectionUtils.setValue(connection, PLAYER_NAME, player.getCorrectUsername());
+            }
         }
     }
 
@@ -119,6 +135,18 @@ public final class BungeeListener implements Listener {
         // he has been disconnected by now
         UUID uniqueId = event.getConnection().getUniqueId();
         FloodgatePlayer player = api.getPlayer(uniqueId);
+
+        if (player == null && config.isAllowOnlineModeAuthentication()) {
+            player = playerCache.getIfPresent(event.getConnection());
+            if (player != null) {
+                playerCache.invalidate(event.getConnection());
+                if (player instanceof FloodgatePlayerImpl) {
+                    FloodgatePlayerImpl floodgatePlayer = (FloodgatePlayerImpl) player;
+                    floodgatePlayer.setOnlineModeProfile(uniqueId, event.getConnection().getName());
+                }
+            }
+        }
+
         if (player != null) {
             //todo we should probably move this log message earlier in the process, so that we know
             // that Floodgate has done its job

--- a/core/src/main/java/org/geysermc/floodgate/config/ProxyFloodgateConfig.java
+++ b/core/src/main/java/org/geysermc/floodgate/config/ProxyFloodgateConfig.java
@@ -33,4 +33,5 @@ import lombok.Getter;
 @Getter
 public final class ProxyFloodgateConfig extends FloodgateConfig {
     private boolean sendFloodgateData;
+    private boolean allowOnlineModeAuthentication;
 }

--- a/core/src/main/java/org/geysermc/floodgate/player/FloodgatePlayerImpl.java
+++ b/core/src/main/java/org/geysermc/floodgate/player/FloodgatePlayerImpl.java
@@ -66,6 +66,9 @@ public final class FloodgatePlayerImpl implements FloodgatePlayer {
     private final int subscribeId;
     private final String verifyCode;
 
+    private UUID onlineModeUniqueId;
+    private String onlineModeUsername;
+
     @Getter(AccessLevel.PRIVATE)
     private Map<PropertyKey, Object> propertyKeyToValue;
     @Getter(AccessLevel.PRIVATE)
@@ -91,12 +94,25 @@ public final class FloodgatePlayerImpl implements FloodgatePlayer {
 
     @Override
     public UUID getCorrectUniqueId() {
-        return linkedPlayer != null ? linkedPlayer.getJavaUniqueId() : javaUniqueId;
+        if (linkedPlayer != null) {
+            return linkedPlayer.getJavaUniqueId();
+        }
+
+        return onlineModeUniqueId != null ? onlineModeUniqueId : javaUniqueId;
     }
 
     @Override
     public String getCorrectUsername() {
-        return linkedPlayer != null ? linkedPlayer.getJavaUsername() : javaUsername;
+        if (linkedPlayer != null) {
+            return linkedPlayer.getJavaUsername();
+        }
+
+        return onlineModeUsername != null ? onlineModeUsername : javaUsername;
+    }
+
+    public void setOnlineModeProfile(UUID uniqueId, String username) {
+        this.onlineModeUniqueId = uniqueId;
+        this.onlineModeUsername = username;
     }
 
     @Override
@@ -105,8 +121,18 @@ public final class FloodgatePlayerImpl implements FloodgatePlayer {
     }
 
     public BedrockData toBedrockData() {
+        LinkedPlayer forwardedLinkedPlayer = this.linkedPlayer;
+        if (forwardedLinkedPlayer == null) {
+            UUID correctUniqueId = getCorrectUniqueId();
+            String correctUsername = getCorrectUsername();
+
+            if (!javaUniqueId.equals(correctUniqueId) || !javaUsername.equals(correctUsername)) {
+                forwardedLinkedPlayer = LinkedPlayer.of(correctUsername, correctUniqueId, javaUniqueId);
+            }
+        }
+
         return BedrockData.of(version, username, xuid, deviceOs.ordinal(), languageCode,
-                uiProfile.ordinal(), inputMode.ordinal(), ip, linkedPlayer, proxy, subscribeId,
+                uiProfile.ordinal(), inputMode.ordinal(), ip, forwardedLinkedPlayer, proxy, subscribeId,
                 verifyCode);
     }
 

--- a/core/src/main/resources/proxy-config.yml
+++ b/core/src/main/resources/proxy-config.yml
@@ -5,5 +5,10 @@
 # You'll get kicked if you don't use the plugin. The default value is false because of it
 send-floodgate-data: false
 
+# If enabled, Floodgate will not force Bedrock players into offline mode on the proxy.
+# This is useful when Geyser is configured for auth-type: online and you still want
+# Floodgate API support for Bedrock-only plugins.
+allow-online-mode-authentication: false
+
 >>|
 >>*

--- a/velocity/src/main/java/org/geysermc/floodgate/listener/VelocityListener.java
+++ b/velocity/src/main/java/org/geysermc/floodgate/listener/VelocityListener.java
@@ -58,6 +58,7 @@ import org.geysermc.floodgate.api.logger.FloodgateLogger;
 import org.geysermc.floodgate.api.player.FloodgatePlayer;
 import org.geysermc.floodgate.config.ProxyFloodgateConfig;
 import org.geysermc.floodgate.pluginmessage.channel.FormChannel;
+import org.geysermc.floodgate.player.FloodgatePlayerImpl;
 import org.geysermc.floodgate.skin.SkinDataImpl;
 import org.geysermc.floodgate.util.Constants;
 import org.geysermc.floodgate.util.LanguageManager;
@@ -149,7 +150,9 @@ public final class VelocityListener {
         }
 
         if (player != null) {
-            event.setResult(PreLoginEvent.PreLoginComponentResult.forceOfflineMode());
+            if (!config.isAllowOnlineModeAuthentication()) {
+                event.setResult(PreLoginEvent.PreLoginComponentResult.forceOfflineMode());
+            }
             playerCache.put(event.getConnection(), player);
         }
     }
@@ -162,6 +165,16 @@ public final class VelocityListener {
             return;
         }
         playerCache.invalidate(event.getConnection());
+
+        if (config.isAllowOnlineModeAuthentication()) {
+            GameProfile profile = event.getGameProfile();
+            if (player instanceof FloodgatePlayerImpl) {
+                FloodgatePlayerImpl floodgatePlayer = (FloodgatePlayerImpl) player;
+                floodgatePlayer.setOnlineModeProfile(profile.getId(), profile.getName());
+            }
+            continuation.resume();
+            return;
+        }
 
         // Skin look up (on Spigot and friends) would result in it failing, so apply a default skin
         if (!player.isLinked()) {


### PR DESCRIPTION

This pull request introduces support for allowing Bedrock players to authenticate in online mode when using Floodgate, controlled by a new configuration option. The changes ensure that player profile information is handled correctly in both online and offline modes, and update the listeners and player implementation to support this behavior.

**Online Mode Authentication Support:**

* Added a new configuration option `allow-online-mode-authentication` to `proxy-config.yml` and `ProxyFloodgateConfig`, enabling Bedrock players to authenticate in online mode when desired. [[1]](diffhunk://#diff-fa4377454e5c6536d56d8ed7b37b5d199a884745cff8ef2c914ec6b47730f4aeR8-R12) [[2]](diffhunk://#diff-195ddbfbc5039cc770f50cac8e50fb1f8c83085f75327963da1c2f70e6e3bba8R36)
* Updated `BungeeListener` and `VelocityListener` to check the new config option and handle player authentication and caching accordingly, ensuring correct player profile assignment for both modes. [[1]](diffhunk://#diff-e1b2d9b7a0ced56d1a6999f07d33d1af7eeb7f732e9df624171f8435d4758a83R122-R149) [[2]](diffhunk://#diff-8ee1778ba15b3fdbacee20b036e3045c31e0ed205310ba446634a61c3df6dd03R153-R155) [[3]](diffhunk://#diff-8ee1778ba15b3fdbacee20b036e3045c31e0ed205310ba446634a61c3df6dd03R169-R178)

**Player Profile Handling:**

* Modified `FloodgatePlayerImpl` to store and use online mode UUID and username, including methods to set and retrieve the correct profile based on authentication mode. [[1]](diffhunk://#diff-4cb5405e293c15c2d28f3089e3f2aaa557d8e58a58b585d8d287e092ce1b4f82R69-R71) [[2]](diffhunk://#diff-4cb5405e293c15c2d28f3089e3f2aaa557d8e58a58b585d8d287e092ce1b4f82L94-R115)
* Updated `FloodgatePlayerImpl.toBedrockData()` to forward linked player information when online mode authentication is used.

**Listener and Dependency Updates:**

* Injected `ProxyFloodgateConfig` into `BungeeListener` and updated imports to support new features and player handling. [[1]](diffhunk://#diff-e1b2d9b7a0ced56d1a6999f07d33d1af7eeb7f732e9df624171f8435d4758a83R53-R55) [[2]](diffhunk://#diff-e1b2d9b7a0ced56d1a6999f07d33d1af7eeb7f732e9df624171f8435d4758a83R83)
* Introduced a player cache in `BungeeListener` to temporarily store player data for online mode authentication scenarios.

---

**Note**

This is an **attempt to address issue #634**. From a code perspective the changes should make sense, but I cannot guarantee that it works correctly in practice.

I personally **do not use Velocity** and my setup is based on **Spigot**, so this implementation was not tested in a real Velocity environment. The goal of this PR is mainly to provide a **possible direction or reference implementation** for supporting online mode authentication with Floodgate.

If someone who actively uses Velocity can test it and confirm whether it behaves correctly, that would be very helpful.

Probably:
Fixes #634 
