### PR TITLE
Add Education Edition support

### DIFF
--- a/api/src/main/java/org/geysermc/floodgate/api/player/FloodgatePlayer.java
+++ b/api/src/main/java/org/geysermc/floodgate/api/player/FloodgatePlayer.java
@@ -113,6 +113,21 @@ public interface FloodgatePlayer {
      */
     boolean isLinked();
 
+    /**
+     * Returns true if the player is a Minecraft Education Edition client
+     */
+    boolean isEducationPlayer();
+
+    /**
+     * Returns the M365 tenant ID of the education player, or empty string if not an edu player
+     */
+    String getTenantId();
+
+    /**
+     * Returns the AD role of the education player (0 = student, 1 = teacher), or -1 if not edu
+     */
+    int getAdRole();
+
     default boolean sendForm(Form form) {
         return FloodgateApi.getInstance().sendForm(getCorrectUniqueId(), form);
     }

--- a/build-logic/src/main/kotlin/Versions.kt
+++ b/build-logic/src/main/kotlin/Versions.kt
@@ -24,7 +24,7 @@
  */
 
 object Versions {
-    const val geyserVersion = "2.2.1-SNAPSHOT"
+    const val geyserVersion = "2.9.4-SNAPSHOT"
     const val cumulusVersion = "1.1.2"
     const val eventsVersion = "1.1-SNAPSHOT"
     const val configUtilsVersion = "1.0-SNAPSHOT"

--- a/core/src/main/java/org/geysermc/floodgate/addon/data/HandshakeDataImpl.java
+++ b/core/src/main/java/org/geysermc/floodgate/addon/data/HandshakeDataImpl.java
@@ -66,14 +66,25 @@ public class HandshakeDataImpl implements HandshakeData {
         UUID javaUniqueId = null;
 
         if (bedrockData != null) {
-            String prefix = config.getUsernamePrefix();
-            int usernameLength = Math.min(bedrockData.getUsername().length(), 16 - prefix.length());
-            javaUsername = prefix + bedrockData.getUsername().substring(0, usernameLength);
+            if (bedrockData.isEducation()) {
+                String prefix = config.getEducationPrefix();
+                String tenantHash = Utils.getTenantHash(bedrockData.getTenantId());
+                // Format: <prefix><name><4-char-hash>, truncate name if needed
+                int maxNameLength = 16 - prefix.length() - tenantHash.length();
+                int nameLength = Math.min(bedrockData.getUsername().length(), maxNameLength);
+                javaUsername = prefix + bedrockData.getUsername().substring(0, nameLength) + tenantHash;
+
+                javaUniqueId = Utils.getEducationUuid(bedrockData.getTenantId(), bedrockData.getUsername());
+            } else {
+                String prefix = config.getUsernamePrefix();
+                int usernameLength = Math.min(bedrockData.getUsername().length(), 16 - prefix.length());
+                javaUsername = prefix + bedrockData.getUsername().substring(0, usernameLength);
+
+                javaUniqueId = Utils.getJavaUuid(bedrockData.getXuid());
+            }
             if (config.isReplaceSpaces()) {
                 javaUsername = javaUsername.replace(" ", "_");
             }
-
-            javaUniqueId = Utils.getJavaUuid(bedrockData.getXuid());
             this.ip = bedrockData.getIp();
         }
 

--- a/core/src/main/java/org/geysermc/floodgate/api/SimpleFloodgateApi.java
+++ b/core/src/main/java/org/geysermc/floodgate/api/SimpleFloodgateApi.java
@@ -112,7 +112,7 @@ public class SimpleFloodgateApi implements FloodgateApi {
 
     @Override
     public boolean isFloodgateId(UUID uuid) {
-        return uuid.getMostSignificantBits() == 0;
+        return uuid.getMostSignificantBits() == 0 || Utils.isEducationId(uuid);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/floodgate/config/FloodgateConfig.java
+++ b/core/src/main/java/org/geysermc/floodgate/config/FloodgateConfig.java
@@ -41,6 +41,7 @@ import org.geysermc.configutils.loader.callback.GenericPostInitializeCallback;
 public class FloodgateConfig implements GenericPostInitializeCallback<ConfigLoader> {
     private String keyFileName;
     private String usernamePrefix = "";
+    private String educationPrefix = "+";
     private boolean replaceSpaces;
 
     private String defaultLocale;
@@ -82,6 +83,11 @@ public class FloodgateConfig implements GenericPostInitializeCallback<ConfigLoad
         // Java usernames can't be longer than 16 chars
         if (usernamePrefix.length() >= 16) {
             usernamePrefix = ".";
+        }
+
+        // Education prefix + 4 char hash must leave room for at least 1 char username
+        if (educationPrefix.length() + 4 >= 16) {
+            educationPrefix = "+";
         }
 
         return CallbackResult.ok();

--- a/core/src/main/java/org/geysermc/floodgate/player/FloodgateHandshakeHandler.java
+++ b/core/src/main/java/org/geysermc/floodgate/player/FloodgateHandshakeHandler.java
@@ -262,7 +262,8 @@ public final class FloodgateHandshakeHandler {
     }
 
     private CompletableFuture<Pair<BedrockData, LinkedPlayer>> fetchLinkedPlayer(BedrockData data) {
-        if (!api.getPlayerLink().isEnabled()) {
+        // Education players have no Xbox account, skip linking
+        if (!api.getPlayerLink().isEnabled() || data.isEducation()) {
             return CompletableFuture.completedFuture(new ObjectObjectImmutablePair<>(data, null));
         }
         return api.getPlayerLink().getLinkedPlayer(Utils.getJavaUuid(data.getXuid()))

--- a/core/src/main/java/org/geysermc/floodgate/player/FloodgatePlayerImpl.java
+++ b/core/src/main/java/org/geysermc/floodgate/player/FloodgatePlayerImpl.java
@@ -66,6 +66,10 @@ public final class FloodgatePlayerImpl implements FloodgatePlayer {
     private final int subscribeId;
     private final String verifyCode;
 
+    private final boolean education;
+    private final String tenantId;
+    private final int adRole;
+
     @Getter(AccessLevel.PRIVATE)
     private Map<PropertyKey, Object> propertyKeyToValue;
     @Getter(AccessLevel.PRIVATE)
@@ -74,7 +78,12 @@ public final class FloodgatePlayerImpl implements FloodgatePlayer {
     static FloodgatePlayerImpl from(BedrockData data, HandshakeData handshakeData) {
         FloodgateApi api = FloodgateApi.getInstance();
 
-        UUID javaUniqueId = Utils.getJavaUuid(data.getXuid());
+        UUID javaUniqueId;
+        if (data.isEducation()) {
+            javaUniqueId = Utils.getEducationUuid(data.getTenantId(), data.getUsername());
+        } else {
+            javaUniqueId = Utils.getJavaUuid(data.getXuid());
+        }
 
         DeviceOs deviceOs = DeviceOs.fromId(data.getDeviceOs());
         UiProfile uiProfile = UiProfile.fromId(data.getUiProfile());
@@ -86,7 +95,8 @@ public final class FloodgatePlayerImpl implements FloodgatePlayer {
                 data.getVersion(), data.getUsername(), handshakeData.getJavaUsername(),
                 javaUniqueId, data.getXuid(), deviceOs, data.getLanguageCode(), uiProfile,
                 inputMode, data.getIp(), data.isFromProxy(), api instanceof ProxyFloodgateApi,
-                linkedPlayer, data.getSubscribeId(), data.getVerifyCode());
+                linkedPlayer, data.getSubscribeId(), data.getVerifyCode(),
+                data.isEducation(), data.getTenantId(), data.getAdRole());
     }
 
     @Override
@@ -104,10 +114,25 @@ public final class FloodgatePlayerImpl implements FloodgatePlayer {
         return linkedPlayer != null;
     }
 
+    @Override
+    public boolean isEducationPlayer() {
+        return education;
+    }
+
+    @Override
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    @Override
+    public int getAdRole() {
+        return adRole;
+    }
+
     public BedrockData toBedrockData() {
         return BedrockData.of(version, username, xuid, deviceOs.ordinal(), languageCode,
                 uiProfile.ordinal(), inputMode.ordinal(), ip, linkedPlayer, proxy, subscribeId,
-                verifyCode);
+                verifyCode, education, tenantId, adRole);
     }
 
     @Override

--- a/core/src/main/java/org/geysermc/floodgate/util/Utils.java
+++ b/core/src/main/java/org/geysermc/floodgate/util/Utils.java
@@ -35,6 +35,8 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.annotation.Annotation;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.Set;
@@ -93,6 +95,36 @@ public class Utils {
 
     public static UUID getJavaUuid(String xuid) {
         return getJavaUuid(Long.parseLong(xuid));
+    }
+
+    private static final long EDUCATION_UUID_MSB = 0x0000000100000001L;
+
+    public static UUID getEducationUuid(String tenantId, String username) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest((tenantId + ":" + username).getBytes(StandardCharsets.UTF_8));
+            long lsb = 0;
+            for (int i = 0; i < 8; i++) {
+                lsb = (lsb << 8) | (hash[i] & 0xFF);
+            }
+            return new UUID(EDUCATION_UUID_MSB, lsb);
+        } catch (NoSuchAlgorithmException e) {
+            throw new AssertionError("SHA-256 not available", e);
+        }
+    }
+
+    public static boolean isEducationId(UUID uuid) {
+        return uuid.getMostSignificantBits() == EDUCATION_UUID_MSB;
+    }
+
+    public static String getTenantHash(String tenantId) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(tenantId.getBytes(StandardCharsets.UTF_8));
+            return String.format("%02x%02x", hash[0], hash[1]);
+        } catch (NoSuchAlgorithmException e) {
+            throw new AssertionError("SHA-256 not available", e);
+        }
     }
 
     public static boolean isUniquePrefix(String prefix) {

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -8,6 +8,10 @@ key-file-name: key.pem
 # It is recommended to use a prefix that does not contain alphanumerical to avoid the possibility of duplicate usernames.
 username-prefix: "."
 
+# The prefix used for Education Edition players. A 4-character tenant hash is also appended
+# to distinguish players from different M365 tenants.
+education-prefix: "+"
+
 # Should spaces be replaced with '_' in bedrock usernames?
 replace-spaces: true
 


### PR DESCRIPTION
Companion PR to the EduGeyser PR (GeyserMC/Geyser#6251).
 
## Changes
 
- Add education fields to `BedrockData` (education flag, tenantId, adRole), coordinated format change with Geyser, `EXPECTED_LENGTH` 12 to 15
- Add deterministic UUID generation for education players (SHA-256 of tenantId:username, fixed MSB `0x0000000100000001`)
- Add education username format: `+<name><4-char-tenant-hash>` with configurable prefix
- Add `isEducationPlayer()`, `getTenantId()`, `getAdRole()` to `FloodgatePlayer` API
- Skip player linking for education players (no Xbox account)
- Recognize education UUIDs in `isFloodgateId()`
 
**Requires the corresponding Geyser PR.** The BedrockData format change must be paired.
 
See the Geyser PR for full context, technical documentation, and testing details.