### PR TITLE
Update cloud-paper to 2.0.0-SNAPSHOT for Paper 26.1 support

### DIFF
--- a/build-logic/src/main/kotlin/Versions.kt
+++ b/build-logic/src/main/kotlin/Versions.kt
@@ -33,7 +33,7 @@ object Versions {
     const val guiceVersion = "6.0.0"
     const val nettyVersion = "4.1.49.Final"
     const val snakeyamlVersion = "1.28"
-    const val cloudVersion = "2.0.0-beta.13" // for cloud-minecraft
+    const val cloudVersion = "2.0.0-SNAPSHOT" // for cloud-minecraft
     const val cloudCore = "2.0.0-rc.2"
     const val bstatsVersion = "3.0.2"
 

--- a/build-logic/src/main/kotlin/Versions.kt
+++ b/build-logic/src/main/kotlin/Versions.kt
@@ -33,8 +33,8 @@ object Versions {
     const val guiceVersion = "6.0.0"
     const val nettyVersion = "4.1.49.Final"
     const val snakeyamlVersion = "1.28"
-    const val cloudVersion = "2.0.0-SNAPSHOT" // for cloud-minecraft
-    const val cloudCore = "2.0.0-rc.2"
+    const val cloudVersion = "2.0.0-beta.15" // for cloud-minecraft
+    const val cloudCore = "2.0.0"
     const val bstatsVersion = "3.0.2"
 
     const val javaWebsocketVersion = "1.6.0"


### PR DESCRIPTION
Fixes ItemInput.createItemStack reflection crash on Paper 26.1 with Mojang mappings. 