### PR TITLE
Fix Paper 26 startup issues

### DIFF
--- a/build-logic/src/main/kotlin/Versions.kt
+++ b/build-logic/src/main/kotlin/Versions.kt
@@ -33,8 +33,8 @@ object Versions {
     const val guiceVersion = "6.0.0"
     const val nettyVersion = "4.1.49.Final"
     const val snakeyamlVersion = "1.28"
-    const val cloudVersion = "2.0.0-beta.13" // for cloud-minecraft
-    const val cloudCore = "2.0.0-rc.2"
+    const val cloudVersion = "2.0.0-SNAPSHOT" // for cloud-minecraft
+    const val cloudCore = "2.0.0"
     const val bstatsVersion = "3.0.2"
 
     const val javaWebsocketVersion = "1.6.0"

--- a/core/src/main/java/org/geysermc/floodgate/util/LanguageManager.java
+++ b/core/src/main/java/org/geysermc/floodgate/util/LanguageManager.java
@@ -145,7 +145,7 @@ public final class LanguageManager {
      * @return translated string or "key arg1, arg2 (etc.)" if it was not found in the given locale
      */
     public String getString(String key, String locale, Object... values) {
-        Properties properties = localeMappings.get(locale);
+        Properties properties = localeMappings.get(formatLocale(locale));
         String formatString = null;
 
         if (properties != null) {
@@ -153,9 +153,11 @@ public final class LanguageManager {
         }
 
         // try and get the key from the default locale
-        if (formatString == null) {
+        if (formatString == null && defaultLocale != null) {
             properties = localeMappings.get(defaultLocale);
-            formatString = properties.getProperty(key);
+            if (properties != null) {
+                formatString = properties.getProperty(key);
+            }
         }
 
         // key wasn't found

--- a/spigot/src/main/java/org/geysermc/floodgate/inject/spigot/SpigotInjector.java
+++ b/spigot/src/main/java/org/geysermc/floodgate/inject/spigot/SpigotInjector.java
@@ -31,7 +31,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.channel.ChannelInitializer;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
@@ -45,6 +44,17 @@ import org.geysermc.floodgate.util.ReflectionUtils;
 
 @Singleton
 public final class SpigotInjector extends CommonPlatformInjector {
+    private static final String[] EARLY_LOAD_CLASSES = {
+            "org.geysermc.floodgate.inject.spigot.SpigotInjector$ServerChannelHandler",
+            "org.geysermc.floodgate.inject.spigot.SpigotInjector$ChildChannelHandler",
+            "org.geysermc.floodgate.addon.data.PacketBlocker",
+            "org.geysermc.floodgate.addon.data.SpigotDataHandler",
+            "org.geysermc.floodgate.addon.packethandler.ChannelInPacketHandler",
+            "org.geysermc.floodgate.addon.packethandler.ChannelOutPacketHandler",
+            "org.geysermc.floodgate.addon.debug.ChannelInDebugHandler",
+            "org.geysermc.floodgate.addon.debug.ChannelOutDebugHandler"
+    };
+
     @Inject private FloodgateLogger logger;
 
     private Object serverConnection;
@@ -58,6 +68,8 @@ public final class SpigotInjector extends CommonPlatformInjector {
         if (isInjected()) {
             return;
         }
+
+        warmupRuntimeClasses();
 
         Object serverConnection = getServerConnection();
         if (serverConnection == null) {
@@ -107,22 +119,7 @@ public final class SpigotInjector extends CommonPlatformInjector {
     }
 
     public void injectClient(ChannelFuture future) {
-        future.channel().pipeline().addFirst("floodgate-init", new ChannelInboundHandlerAdapter() {
-            @Override
-            public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-                Channel channel = (Channel) msg;
-                channel.pipeline().addLast("floodgate-injector", new ChannelInboundHandlerAdapter() {
-                    @Override
-                    public void channelActive(ChannelHandlerContext childCtx) throws Exception {
-                        injectAddonsCall(childCtx.channel(), false);
-                        addInjectedClient(childCtx.channel());
-                        childCtx.pipeline().remove(this);
-                        super.channelActive(childCtx);
-                    }
-                });
-                super.channelRead(ctx, msg);
-            }
-        });
+        future.channel().pipeline().addFirst("floodgate-init", new ServerChannelHandler(this));
     }
 
     @Override
@@ -183,5 +180,47 @@ public final class SpigotInjector extends CommonPlatformInjector {
         serverConnection = ReflectionUtils.invoke(minecraftServerInstance, method);
 
         return serverConnection;
+    }
+
+    private static void warmupRuntimeClasses() {
+        ClassLoader classLoader = SpigotInjector.class.getClassLoader();
+        for (String className : EARLY_LOAD_CLASSES) {
+            try {
+                Class.forName(className, false, classLoader);
+            } catch (ClassNotFoundException exception) {
+                throw new IllegalStateException("Failed to preload runtime class " + className, exception);
+            }
+        }
+    }
+
+    private static final class ServerChannelHandler extends ChannelInboundHandlerAdapter {
+        private final SpigotInjector injector;
+
+        private ServerChannelHandler(SpigotInjector injector) {
+            this.injector = injector;
+        }
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+            Channel channel = (Channel) msg;
+            channel.pipeline().addLast("floodgate-injector", new ChildChannelHandler(injector));
+            super.channelRead(ctx, msg);
+        }
+    }
+
+    private static final class ChildChannelHandler extends ChannelInboundHandlerAdapter {
+        private final SpigotInjector injector;
+
+        private ChildChannelHandler(SpigotInjector injector) {
+            this.injector = injector;
+        }
+
+        @Override
+        public void channelActive(ChannelHandlerContext childCtx) throws Exception {
+            injector.injectAddonsCall(childCtx.channel(), false);
+            injector.addInjectedClient(childCtx.channel());
+            childCtx.pipeline().remove(this);
+            super.channelActive(childCtx);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- update Floodgate's Cloud dependencies so command registration works on newer Paper builds
- normalize locale lookups and guard the fallback path so missing locale state does not blow up startup
- eagerly preload the Spigot injector runtime classes so Paper does not try to lazy-load them from a closing plugin jar on Netty threads

## Root cause
- the older Cloud versions in Floodgate fail against newer Paper item parsing internals
- locale fallback assumed the default locale properties were always loaded
- the injector still relied on lazy class loading during connection setup

## Validation
- .\gradlew.bat clean build
