### PR TITLE
added suffix

### DIFF
--- a/api/src/main/java/org/geysermc/floodgate/api/FloodgateApi.java
+++ b/api/src/main/java/org/geysermc/floodgate/api/FloodgateApi.java
@@ -50,6 +50,14 @@ public interface FloodgateApi {
     String getPlayerPrefix();
 
     /**
+     * Returns the character(s) that will be appended at the end of a Bedrock player's name to
+     * prevent username duplicates. Returns an empty string if no suffix is configured.
+     */
+    default String getPlayerSuffix() {
+        return "";
+    }
+
+    /**
      * Returns all the online Floodgate players.
      */
     Collection<FloodgatePlayer> getPlayers();

--- a/core/src/main/java/org/geysermc/floodgate/addon/data/HandshakeDataImpl.java
+++ b/core/src/main/java/org/geysermc/floodgate/addon/data/HandshakeDataImpl.java
@@ -67,8 +67,10 @@ public class HandshakeDataImpl implements HandshakeData {
 
         if (bedrockData != null) {
             String prefix = config.getUsernamePrefix();
-            int usernameLength = Math.min(bedrockData.getUsername().length(), 16 - prefix.length());
-            javaUsername = prefix + bedrockData.getUsername().substring(0, usernameLength);
+            String suffix = config.getUsernameSuffix();
+            int available = 16 - prefix.length() - suffix.length();
+            int usernameLength = Math.min(bedrockData.getUsername().length(), Math.max(available, 1));
+            javaUsername = prefix + bedrockData.getUsername().substring(0, usernameLength) + suffix;
             if (config.isReplaceSpaces()) {
                 javaUsername = javaUsername.replace(" ", "_");
             }

--- a/core/src/main/java/org/geysermc/floodgate/api/SimpleFloodgateApi.java
+++ b/core/src/main/java/org/geysermc/floodgate/api/SimpleFloodgateApi.java
@@ -68,6 +68,11 @@ public class SimpleFloodgateApi implements FloodgateApi {
     }
 
     @Override
+    public String getPlayerSuffix() {
+        return config.getUsernameSuffix();
+    }
+
+    @Override
     public Collection<FloodgatePlayer> getPlayers() {
         return ImmutableSet.copyOf(players.values());
     }

--- a/core/src/main/java/org/geysermc/floodgate/command/WhitelistCommand.java
+++ b/core/src/main/java/org/geysermc/floodgate/command/WhitelistCommand.java
@@ -113,6 +113,10 @@ public class WhitelistCommand implements FloodgateCommand {
         if (name.startsWith(config.getUsernamePrefix())) {
             name = name.substring(config.getUsernamePrefix().length());
         }
+        String suffix = config.getUsernameSuffix();
+        if (!suffix.isEmpty() && name.endsWith(suffix)) {
+            name = name.substring(0, name.length() - suffix.length());
+        }
 
         if (name.isEmpty() || name.length() > 16) {
             sender.sendMessage(Message.INVALID_USERNAME);
@@ -125,7 +129,7 @@ public class WhitelistCommand implements FloodgateCommand {
         if (config.isReplaceSpaces()) {
             tempName = tempName.replace(' ', '_');
         }
-        final String correctName = config.getUsernamePrefix() + tempName;
+        final String correctName = config.getUsernamePrefix() + tempName + suffix;
         final String strippedName = name;
 
         // We need to get the UUID of the player if it's not manually specified

--- a/core/src/main/java/org/geysermc/floodgate/config/FloodgateConfig.java
+++ b/core/src/main/java/org/geysermc/floodgate/config/FloodgateConfig.java
@@ -41,6 +41,7 @@ import org.geysermc.configutils.loader.callback.GenericPostInitializeCallback;
 public class FloodgateConfig implements GenericPostInitializeCallback<ConfigLoader> {
     private String keyFileName;
     private String usernamePrefix = "";
+    private String usernameSuffix = "";
     private boolean replaceSpaces;
 
     private String defaultLocale;
@@ -55,6 +56,7 @@ public class FloodgateConfig implements GenericPostInitializeCallback<ConfigLoad
 
     private Key key;
     private String rawUsernamePrefix;
+    private String rawUsernameSuffix;
 
     public boolean isProxy() {
         return this instanceof ProxyFloodgateConfig;
@@ -78,10 +80,20 @@ public class FloodgateConfig implements GenericPostInitializeCallback<ConfigLoad
         }
 
         rawUsernamePrefix = usernamePrefix;
+        rawUsernameSuffix = usernameSuffix == null ? "" : usernameSuffix;
+        if (usernameSuffix == null) {
+            usernameSuffix = "";
+        }
 
         // Java usernames can't be longer than 16 chars
         if (usernamePrefix.length() >= 16) {
             usernamePrefix = ".";
+        }
+        if (usernameSuffix.length() >= 16) {
+            usernameSuffix = "";
+        }
+        if (usernamePrefix.length() + usernameSuffix.length() >= 16) {
+            usernameSuffix = "";
         }
 
         return CallbackResult.ok();

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -8,6 +8,9 @@ key-file-name: key.pem
 # It is recommended to use a prefix that does not contain alphanumerical to avoid the possibility of duplicate usernames.
 username-prefix: "."
 
+# Optional suffix appended after a bedrock player's name. Leave empty to disable.
+username-suffix: ""
+
 # Should spaces be replaced with '_' in bedrock usernames?
 replace-spaces: true
 


### PR DESCRIPTION
Appends a suffix to bedrock usernames. Can be used together with username-prefix or on its own. Useful when a plugin checks the start of the username and breaks if a prefix is set. Empty by default.