### PR TITLE
Update to 26.2

### DIFF
--- a/build-logic/src/main/kotlin/Versions.kt
+++ b/build-logic/src/main/kotlin/Versions.kt
@@ -33,7 +33,7 @@ object Versions {
     const val guiceVersion = "6.0.0"
     const val nettyVersion = "4.1.49.Final"
     const val snakeyamlVersion = "1.28"
-    const val cloudVersion = "2.0.0-beta.15" // for cloud-minecraft
+    const val cloudVersion = "2.0.0-SNAPSHOT" // for cloud-minecraft
     const val cloudCore = "2.0.0"
     const val bstatsVersion = "3.0.2"
 

--- a/build-logic/src/main/kotlin/Versions.kt
+++ b/build-logic/src/main/kotlin/Versions.kt
@@ -33,7 +33,7 @@ object Versions {
     const val guiceVersion = "6.0.0"
     const val nettyVersion = "4.1.49.Final"
     const val snakeyamlVersion = "1.28"
-    const val cloudVersion = "2.0.0-SNAPSHOT" // for cloud-minecraft
+    const val cloudVersion = "2.0.0-beta.16" // for cloud-minecraft
     const val cloudCore = "2.0.0"
     const val bstatsVersion = "3.0.2"
 

--- a/bungee/build.gradle.kts
+++ b/bungee/build.gradle.kts
@@ -2,11 +2,10 @@ var bungeeProxyVersion = "1.21-R0.1-SNAPSHOT"
 var bungeeApiVersion = "1.21-R0.1"
 var gsonVersion = "2.8.0"
 var guavaVersion = "21.0"
-var cloudVersion = "2.0.0-20260617.222640-44"
 
 dependencies {
     api(projects.core)
-    implementation("org.incendo", "cloud-bungee", cloudVersion)
+    implementation("org.incendo", "cloud-bungee", Versions.cloudVersion)
 }
 
 relocate("com.google.inject")

--- a/spigot/build.gradle.kts
+++ b/spigot/build.gradle.kts
@@ -1,7 +1,6 @@
 var authlibVersion = "1.5.21"
 var guavaVersion = "21.0"
 var gsonVersion = "2.8.5"
-var cloudVersion = "2.0.0-20260617.222640-43"
 
 indra {
     javaVersions {
@@ -14,7 +13,7 @@ indra {
 dependencies {
     api(projects.core)
 
-    implementation("org.incendo", "cloud-paper", cloudVersion)
+    implementation("org.incendo", "cloud-paper", Versions.cloudVersion)
     // hack to make pre 1.12 work
     implementation("com.google.guava", "guava", guavaVersion)
 

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -2,7 +2,6 @@ var velocityVersion = "3.2.0-SNAPSHOT"
 var log4jVersion = "2.11.2"
 var gsonVersion = "2.8.8"
 var guavaVersion = "25.1-jre"
-var cloudVersion = "2.0.0-20260617.222640-43"
 
 indra {
     javaVersions {
@@ -13,7 +12,7 @@ indra {
 
 dependencies {
     api(projects.core)
-    implementation("org.incendo", "cloud-velocity", cloudVersion)
+    implementation("org.incendo", "cloud-velocity", Versions.cloudVersion)
 }
 
 relocate("org.incendo.cloud")


### PR DESCRIPTION
This PR updates Floodgate to Minecraft 26.2 by simply bumping the Cloud dependency, which is pinned to a `SNAPSHOT` build for now.